### PR TITLE
refactor: migrate Auth Context to React Query

### DIFF
--- a/client/src/contexts/auth-context.tsx
+++ b/client/src/contexts/auth-context.tsx
@@ -1,7 +1,9 @@
-import { createContext, useContext, useEffect, useState, type ReactNode, type JSX } from "react";
+import { createContext, useContext, type ReactNode, type JSX } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api.js";
 import { AuthMeSchema } from "@/lib/schemas.js";
 import type { UserRole } from "@/lib/schemas.js";
+import { queryKeys } from "@/lib/query-keys.js";
 
 interface AuthContextValue {
 	role: UserRole | null;
@@ -18,30 +20,18 @@ const AuthContext = createContext<AuthContextValue>({
 });
 
 export function AuthProvider({ children }: { children: ReactNode }): JSX.Element {
-	const [role, setRole] = useState<UserRole | null>(null);
-	const [username, setUsername] = useState<string | null>(null);
-	const [loading, setLoading] = useState(true);
+	const { data: authData, isLoading } = useQuery({
+		queryKey: queryKeys.auth.me,
+		queryFn: () => apiFetch("/auth/me", AuthMeSchema),
+		retry: false,
+	});
 
-	useEffect(() => {
-		const fetchMe = async (): Promise<void> => {
-			try {
-				const data = await apiFetch("/auth/me", AuthMeSchema);
-				setRole(data.user?.role ?? null);
-				setUsername(data.user?.username ?? null);
-			} catch {
-				setRole(null);
-				setUsername(null);
-			} finally {
-				setLoading(false);
-			}
-		};
-		fetchMe();
-	}, []);
-
+	const role = authData?.user?.role ?? null;
+	const username = authData?.user?.username ?? null;
 	const canModify = role === "admin" || role === "operator";
 
 	return (
-		<AuthContext.Provider value={{ role, username, loading, canModify }}>
+		<AuthContext.Provider value={{ role, username, loading: isLoading, canModify }}>
 			{children}
 		</AuthContext.Provider>
 	);


### PR DESCRIPTION
## Summary

Migrate the Auth Context from useEffect hooks to React Query (TanStack Query).

### Changes
- Replace useEffect + useState with useQuery hook
- Use queryKeys.auth.me for query caching
- Set retry: false to avoid retrying on 401 errors
- Derive role, username, and canModify from query data

### Benefits
- Automatic caching of auth state
- Better error handling
- Consistent with other data fetching in the app
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `AuthProvider` in `auth-context.tsx` to use React Query for improved caching and error handling.
> 
>   - **Refactor `AuthProvider` in `auth-context.tsx`:**
>     - Replace `useEffect` and `useState` with `useQuery` from React Query.
>     - Use `queryKeys.auth.me` for caching.
>     - Set `retry: false` to prevent retries on 401 errors.
>     - Derive `role`, `username`, and `canModify` from query data.
>   - **Benefits:**
>     - Improved caching and error handling.
>     - Consistent data fetching approach across the app.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fdocklight&utm_source=github&utm_medium=referral)<sup> for 41d2857fd08ccd119ed030a99eea5235a1144079. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->