### PR TITLE
refactor: migrate Plugins page to React Query

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.67.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.576.0",

--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -1,0 +1,27 @@
+export const queryKeys = {
+	apps: {
+		all: ["apps"] as const,
+		detail: (name: string) => ["apps", name] as const,
+		config: (name: string) => ["apps", name, "config"] as const,
+		domains: (name: string) => ["apps", name, "domains"] as const,
+		ssl: (name: string) => ["apps", name, "ssl"] as const,
+		deployment: (name: string) => ["apps", name, "deployment"] as const,
+		ports: (name: string) => ["apps", name, "ports"] as const,
+		proxy: (name: string) => ["apps", name, "proxy"] as const,
+		buildpacks: (name: string) => ["apps", name, "buildpacks"] as const,
+		dockerOptions: (name: string) => ["apps", name, "docker-options"] as const,
+		network: (name: string) => ["apps", name, "network"] as const,
+	},
+	users: ["users"] as const,
+	plugins: ["plugins"] as const,
+	databases: ["databases"] as const,
+	health: ["health"] as const,
+	commands: ["commands"] as const,
+	audit: {
+		logs: (filters: object) => ["audit", "logs", filters] as const,
+		users: (filters: object) => ["audit", "users", filters] as const,
+	},
+	auth: {
+		me: ["auth", "me"] as const,
+	},
+};

--- a/client/src/pages/Plugins.test.tsx
+++ b/client/src/pages/Plugins.test.tsx
@@ -1,8 +1,25 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../lib/schemas.js";
 import { Plugins } from "./Plugins";
+
+const createTestQueryClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	});
+
+const renderWithQueryClient = (ui: React.ReactElement) => {
+	const testQueryClient = createTestQueryClient();
+	return render(
+		<QueryClientProvider client={testQueryClient}>{ui}</QueryClientProvider>,
+	);
+};
 
 vi.mock("../lib/api.js", () => ({
 	apiFetch: vi.fn(),
@@ -44,7 +61,7 @@ describe("Plugins", () => {
 		const { apiFetch } = await import("../lib/api.js");
 		vi.mocked(apiFetch).mockResolvedValue(mockPlugins);
 
-		render(
+		renderWithQueryClient(
 			<MemoryRouter>
 				<Plugins />
 			</MemoryRouter>
@@ -63,7 +80,7 @@ describe("Plugins", () => {
 		const { apiFetch } = await import("../lib/api.js");
 		vi.mocked(apiFetch).mockResolvedValue([]);
 
-		render(
+		renderWithQueryClient(
 			<MemoryRouter>
 				<Plugins />
 			</MemoryRouter>
@@ -82,7 +99,7 @@ describe("Plugins", () => {
 		const { apiFetch } = await import("../lib/api.js");
 		vi.mocked(apiFetch).mockRejectedValue(new Error("Failed to connect"));
 
-		render(
+		renderWithQueryClient(
 			<MemoryRouter>
 				<Plugins />
 			</MemoryRouter>
@@ -97,7 +114,7 @@ describe("Plugins", () => {
 		const { apiFetch } = await import("../lib/api.js");
 		vi.mocked(apiFetch).mockResolvedValue(mockPlugins);
 
-		render(
+		renderWithQueryClient(
 			<MemoryRouter>
 				<Plugins />
 			</MemoryRouter>

--- a/client/src/pages/Plugins.tsx
+++ b/client/src/pages/Plugins.tsx
@@ -1,31 +1,16 @@
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { apiFetch } from "../lib/api.js";
-import type { PluginInfo } from "../lib/schemas.js";
 import { PluginInfoSchema } from "../lib/schemas.js";
+import { queryKeys } from "../lib/query-keys.js";
 
 export function Plugins() {
-	const [plugins, setPlugins] = useState<PluginInfo[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
+	const { data: plugins, isLoading, error } = useQuery({
+		queryKey: queryKeys.plugins,
+		queryFn: () => apiFetch("/plugins", z.array(PluginInfoSchema)),
+	});
 
-	useEffect(() => {
-		const fetchPlugins = async () => {
-			setLoading(true);
-			setError(null);
-			try {
-				const pluginData = await apiFetch("/plugins", z.array(PluginInfoSchema));
-				setPlugins(pluginData);
-			} catch (err) {
-				setError(err instanceof Error ? err.message : "Failed to load plugins");
-			} finally {
-				setLoading(false);
-			}
-		};
-		fetchPlugins();
-	}, []);
-
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div className="flex justify-center items-center py-12">
 				<div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
@@ -35,7 +20,7 @@ export function Plugins() {
 
 	if (error) {
 		return (
-			<div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">{error}</div>
+			<div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">{error.message}</div>
 		);
 	}
 
@@ -45,7 +30,7 @@ export function Plugins() {
 
 			<div className="bg-white rounded-lg shadow p-6">
 				<h2 className="text-lg font-semibold mb-4">Installed Plugins</h2>
-				{plugins.length === 0 ? (
+				{(plugins ?? []).length === 0 ? (
 					<div>
 						<p className="text-gray-500 mb-4">No plugins found</p>
 						<div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
@@ -66,7 +51,7 @@ export function Plugins() {
 					</div>
 				) : (
 					<div className="space-y-3">
-						{plugins.map((plugin) => (
+						{(plugins ?? []).map((plugin) => (
 							<div
 								key={plugin.name}
 								className="border rounded p-4 flex items-center justify-between gap-4"


### PR DESCRIPTION
## Summary
- Migrated Plugins page from useEffect/useState to React Query (TanStack Query)
- Replaced manual data fetching with useQuery hook
- Updated tests to use QueryClientProvider wrapper

## Changes
- Import useQuery from @tanstack/react-query
- Import queryKeys from lib/query-keys.ts
- Replace useEffect + useState with useQuery
- Update UI to use isLoading, data (with nullish coalescing), and error?.message
- Add QueryClientProvider wrapper in tests

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] All tests pass (115 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `Plugins` page to use React Query for data fetching, updating UI and tests accordingly.
> 
>   - **Behavior**:
>     - Migrated `Plugins` page from `useEffect`/`useState` to `useQuery` from `@tanstack/react-query` in `Plugins.tsx`.
>     - Updated UI to handle loading with `isLoading` and errors with `error?.message`.
>   - **Tests**:
>     - Added `QueryClientProvider` wrapper in `Plugins.test.tsx` to support React Query.
>     - Created `createTestQueryClient` and `renderWithQueryClient` for testing.
>   - **Misc**:
>     - Added `@tanstack/react-query` to `dependencies` in `package.json`.
>     - Added `queryKeys` in `query-keys.ts` for managing query keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fdocklight&utm_source=github&utm_medium=referral)<sup> for 97211586923534e7faabf47b07df28b0b87c2a9f. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->