### PR TITLE
feat: link databases to apps

### DIFF
--- a/client/src/pages/AppDetail/Dialogs.tsx
+++ b/client/src/pages/AppDetail/Dialogs.tsx
@@ -9,6 +9,7 @@ interface ConfirmDialogProps {
 	onConfirm: () => void;
 	confirmDisabled?: boolean;
 	submitting?: boolean;
+	submittingText?: string;
 	confirmText?: string;
 	isDestructive?: boolean;
 	children: ReactNode;
@@ -21,6 +22,7 @@ export function ConfirmDialog({
 	onConfirm,
 	confirmDisabled = false,
 	submitting = false,
+	submittingText = "Processing...",
 	confirmText = "Confirm",
 	isDestructive = false,
 	children,
@@ -80,7 +82,7 @@ export function ConfirmDialog({
 						className={`px-4 py-2 ${buttonClass} disabled:bg-gray-300 disabled:cursor-not-allowed`}
 						type="button"
 					>
-						{submitting ? "Processing..." : confirmText}
+						{submitting ? submittingText : confirmText}
 					</button>
 				</div>
 			</div>

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -56,6 +56,7 @@ export function Databases() {
 	// Link database state
 	const [linkDbName, setLinkDbName] = useState("");
 	const [linkAppName, setLinkAppName] = useState("");
+	const [linkAlias, setLinkAlias] = useState("");
 
 	// Unlink database state
 	const [showUnlinkDialog, setShowUnlinkDialog] = useState(false);
@@ -98,11 +99,16 @@ export function Databases() {
 		if (!linkDbName || !linkAppName || linkSubmitting) return;
 
 		setLinkSubmitting(true);
+		const payload: Record<string, string> = { plugin: getDbPlugin(linkDbName), app: linkAppName };
+		if (linkAlias.trim()) {
+			payload.alias = linkAlias.trim();
+		}
 		await streamAction(`/databases/${encodeURIComponent(linkDbName)}/link`, "link database", {
-			body: JSON.stringify({ plugin: getDbPlugin(linkDbName), app: linkAppName }),
+			body: JSON.stringify(payload),
 			onSuccess: () => {
 				setLinkDbName("");
 				setLinkAppName("");
+				setLinkAlias("");
 				void queryClient.invalidateQueries({ queryKey: queryKeys.databases });
 				void queryClient.refetchQueries({ queryKey: queryKeys.databases });
 			},
@@ -372,6 +378,17 @@ export function Databases() {
 															</option>
 														))}
 												</select>
+												<input
+													type="text"
+													placeholder="Env alias (optional)"
+													value={linkDbName === db.name ? linkAlias : ""}
+													onChange={(e) => {
+														setLinkDbName(db.name);
+														setLinkAlias(e.target.value);
+													}}
+													className="border rounded px-3 py-2 text-sm w-40"
+													title="Custom environment variable name (e.g. BLUE_DATABASE). Appends _URL automatically."
+												/>
 												<button
 													onClick={handleLinkDatabase}
 													disabled={linkAppName === "" || linkDbName !== db.name || linkSubmitting}

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from "../lib/api.js";
 import { useAuth } from "@/contexts/auth-context.js";
 import { queryKeys } from "../lib/query-keys.js";
 import { AppSchema, type Database, DatabaseSchema } from "../lib/schemas.js";
+import { ConfirmDialog } from "./AppDetail/Dialogs.js";
 
 const SUPPORTED_PLUGINS = ["postgres", "redis", "mysql", "mariadb", "mongo"];
 
@@ -419,38 +420,26 @@ export function Databases() {
 			)}
 
 			{/* Unlink Confirmation Dialog */}
-			{showUnlinkDialog && (
-				<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-					<div className="bg-white rounded p-6 max-w-md w-full">
-						<h2 className="text-lg font-semibold mb-4">Confirm Unlink</h2>
-						<p className="mb-6">
-							Are you sure you want to unlink <strong>{pendingUnlinkApp}</strong> from{" "}
-							<strong>{pendingUnlinkDb}</strong>?
-						</p>
-						<div className="flex justify-end space-x-2">
-							<button
-								onClick={() => {
-									if (unlinkSubmitting) return;
-									setShowUnlinkDialog(false);
-									setPendingUnlinkDb("");
-									setPendingUnlinkApp("");
-								}}
-								disabled={unlinkSubmitting}
-								className="px-4 py-2 border rounded hover:bg-gray-100 disabled:bg-gray-100 disabled:cursor-not-allowed"
-							>
-								Cancel
-							</button>
-							<button
-								onClick={confirmUnlinkDatabase}
-								disabled={unlinkSubmitting}
-								className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
-							>
-								{unlinkSubmitting ? "Unlinking..." : "Unlink"}
-							</button>
-						</div>
-					</div>
-				</div>
-			)}
+			<ConfirmDialog
+				visible={showUnlinkDialog}
+				title="Confirm Unlink"
+				onClose={() => {
+					if (unlinkSubmitting) return;
+					setShowUnlinkDialog(false);
+					setPendingUnlinkDb("");
+					setPendingUnlinkApp("");
+				}}
+				onConfirm={confirmUnlinkDatabase}
+				submitting={unlinkSubmitting}
+				submittingText="Unlinking..."
+				confirmText="Unlink"
+				isDestructive={true}
+			>
+				<p>
+					Are you sure you want to unlink <strong>{pendingUnlinkApp}</strong> from{" "}
+					<strong>{pendingUnlinkDb}</strong>?
+				</p>
+			</ConfirmDialog>
 
 			{/* Destroy Confirmation Dialog */}
 			{showDestroyDialog && (

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -372,7 +372,7 @@ export function Databases() {
 												>
 													<option value="">Select app</option>
 													{apps
-														.filter((app) => !db.linkedApps.includes(app.name))
+														.filter((app) => !db.linkedApps.includes(app.name.toLowerCase()))
 														.map((app) => (
 															<option key={app.name} value={app.name}>
 																{app.name}

--- a/server/lib/app-events.test.ts
+++ b/server/lib/app-events.test.ts
@@ -35,7 +35,11 @@ describe("app-events", () => {
 		const unsubscribe = subscribeToAppEvents(listener);
 		unsubscribe();
 
-		broadcastAppEvent({ type: "app:stop", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" });
+		broadcastAppEvent({
+			type: "app:stop",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		});
 
 		expect(listener).not.toHaveBeenCalled();
 	});
@@ -68,7 +72,11 @@ describe("app-events", () => {
 
 		unsub1();
 
-		broadcastAppEvent({ type: "app:scale", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" });
+		broadcastAppEvent({
+			type: "app:scale",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		});
 
 		expect(listener1).not.toHaveBeenCalled();
 		expect(listener2).toHaveBeenCalled();

--- a/server/lib/app-events.ts
+++ b/server/lib/app-events.ts
@@ -20,7 +20,10 @@ export function broadcastAppEvent(event: AppEvent): void {
 		try {
 			listener(event);
 		} catch (err) {
-			logger.error({ err, eventType: event.type, appName: event.appName }, "Error in app event listener");
+			logger.error(
+				{ err, eventType: event.type, appName: event.appName },
+				"Error in app event listener"
+			);
 		}
 	}
 }

--- a/server/lib/apps.ts
+++ b/server/lib/apps.ts
@@ -191,7 +191,10 @@ export function parseStatus(stdout: string): "running" | "stopped" {
 	}
 
 	if (sawAnyContent) {
-		logger.warn({ stdout }, "parseStatus: no recognizable status format found, defaulting to stopped");
+		logger.warn(
+			{ stdout },
+			"parseStatus: no recognizable status format found, defaulting to stopped"
+		);
 	}
 
 	return "stopped";
@@ -256,8 +259,7 @@ export function parseDomains(stdout: string): string[] {
 	}
 
 	if (domains.size === 0 && stdout.trim()) {
-		const hasDomainsContent =
-			/domains/i.test(stdout) || /vhost/i.test(stdout);
+		const hasDomainsContent = /domains/i.test(stdout) || /vhost/i.test(stdout);
 		if (hasDomainsContent && !enabledLine) {
 			logger.warn(
 				{ stdout },

--- a/server/lib/databases.parsing.test.ts
+++ b/server/lib/databases.parsing.test.ts
@@ -3,21 +3,12 @@ import { parseInstalledPlugins, parseLinkedApps } from "./databases.js";
 
 describe("parseInstalledPlugins", () => {
 	it("should detect dokku-postgres from plugin list", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-postgres",
-			"dokku-builder-dockerfile",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-postgres", "dokku-builder-dockerfile"].join("\n");
 		expect(parseInstalledPlugins(output)).toEqual(["postgres"]);
 	});
 
 	it("should detect multiple plugins", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-postgres",
-			"dokku-redis",
-			"dokku-mysql",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-postgres", "dokku-redis", "dokku-mysql"].join("\n");
 		expect(parseInstalledPlugins(output)).toContain("postgres");
 		expect(parseInstalledPlugins(output)).toContain("redis");
 		expect(parseInstalledPlugins(output)).toContain("mysql");
@@ -40,11 +31,9 @@ describe("parseInstalledPlugins", () => {
 	});
 
 	it("should return empty array when no supported plugins found", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-builder-dockerfile",
-			"dokku-letsencrypt",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-builder-dockerfile", "dokku-letsencrypt"].join(
+			"\n"
+		);
 		expect(parseInstalledPlugins(output)).toEqual([]);
 	});
 
@@ -88,11 +77,7 @@ describe("parseInstalledPlugins", () => {
 
 describe("parseLinkedApps", () => {
 	it("should parse multi-line linked apps from Dokku 0.30.x links output", () => {
-		const output = [
-			"=====> main-db linked apps",
-			"api",
-			"worker",
-		].join("\n");
+		const output = ["=====> main-db linked apps", "api", "worker"].join("\n");
 		expect(parseLinkedApps(output)).toEqual(["api", "worker"]);
 	});
 

--- a/server/lib/databases.ts
+++ b/server/lib/databases.ts
@@ -236,7 +236,8 @@ export async function createDatabase(
 export async function linkDatabase(
 	plugin: string,
 	name: string,
-	app: string
+	app: string,
+	alias?: string
 ): Promise<CommandResult | { error: string; exitCode: number }> {
 	// Validate plugin
 	if (!SUPPORTED_PLUGINS.includes(plugin as (typeof SUPPORTED_PLUGINS)[number])) {
@@ -277,7 +278,21 @@ export async function linkDatabase(
 		};
 	}
 
-	const command = DokkuCommands.dbLink(plugin, sanitizedName, sanitizedApp);
+	if (alias) {
+		const trimmedAlias = alias.trim();
+		const sanitizedAlias = trimmedAlias.replace(/[^a-zA-Z0-9_]/g, "");
+		if (sanitizedAlias !== trimmedAlias) {
+			return {
+				error: "Alias contains invalid characters (only letters, numbers, and underscores allowed)",
+				command: "",
+				exitCode: 400,
+			};
+		}
+		// Use the trimmed alias in the command
+		alias = trimmedAlias;
+	}
+
+	const command = DokkuCommands.dbLink(plugin, sanitizedName, sanitizedApp, alias);
 
 	try {
 		return executeCommand(command);

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -292,6 +292,12 @@ describe("DokkuCommands", () => {
 			);
 		});
 
+		it("dbLink returns plugin link command with alias", () => {
+			expect(DokkuCommands.dbLink("postgres", "mydb", "my-app", "BLUE_DATABASE")).toBe(
+				"dokku postgres:link 'mydb' 'my-app' --alias 'BLUE_DATABASE'"
+			);
+		});
+
 		it("dbUnlink returns plugin unlink command", () => {
 			expect(DokkuCommands.dbUnlink("postgres", "mydb", "my-app")).toBe(
 				"dokku postgres:unlink 'mydb' 'my-app'"

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -95,7 +95,7 @@ export interface DokkuCommands {
 	dbLinks(plugin: string, name: string): string;
 	dbInfo(plugin: string, name: string): string;
 	dbCreate(plugin: string, name: string): string;
-	dbLink(plugin: string, name: string, app: string): string;
+	dbLink(plugin: string, name: string, app: string, alias?: string): string;
 	dbUnlink(plugin: string, name: string, app: string): string;
 	dbDestroy(plugin: string, name: string): string;
 
@@ -244,8 +244,8 @@ export const DokkuCommands: DokkuCommands = {
 	dbLinks: (plugin: string, name: string): string => `dokku ${plugin}:links ${shellQuote(name)}`,
 	dbInfo: (plugin: string, name: string): string => `dokku ${plugin}:info ${shellQuote(name)}`,
 	dbCreate: (plugin: string, name: string): string => `dokku ${plugin}:create ${shellQuote(name)}`,
-	dbLink: (plugin: string, name: string, app: string): string =>
-		`dokku ${plugin}:link ${shellQuote(name)} ${shellQuote(app)}`,
+	dbLink: (plugin: string, name: string, app: string, alias?: string): string =>
+		`dokku ${plugin}:link ${shellQuote(name)} ${shellQuote(app)}${alias ? ` --alias ${shellQuote(alias)}` : ""}`,
 	dbUnlink: (plugin: string, name: string, app: string): string =>
 		`dokku ${plugin}:unlink ${shellQuote(name)} ${shellQuote(app)}`,
 	dbDestroy: (plugin: string, name: string): string =>

--- a/server/lib/ports.parsing.test.ts
+++ b/server/lib/ports.parsing.test.ts
@@ -40,11 +40,7 @@ describe("parsePortMappings", () => {
 	});
 
 	it("should parse older Dokku proxy:ports line-per-mapping format", () => {
-		const stdout = [
-			"=====> my-app proxy ports",
-			"http:80:5000",
-			"https:443:5000",
-		].join("\n");
+		const stdout = ["=====> my-app proxy ports", "http:80:5000", "https:443:5000"].join("\n");
 		expect(parsePortMappings(stdout)).toEqual([
 			{ scheme: "http", hostPort: 80, containerPort: 5000 },
 			{ scheme: "https", hostPort: 443, containerPort: 5000 },
@@ -52,10 +48,7 @@ describe("parsePortMappings", () => {
 	});
 
 	it("should parse Dokku 0.30.x proxy:ports single port per line", () => {
-		const stdout = [
-			"=====> my-app proxy information",
-			"       http:3000:3000",
-		].join("\n");
+		const stdout = ["=====> my-app proxy information", "       http:3000:3000"].join("\n");
 		expect(parsePortMappings(stdout)).toEqual([
 			{ scheme: "http", hostPort: 3000, containerPort: 3000 },
 		]);

--- a/server/lib/ssl.parsing.test.ts
+++ b/server/lib/ssl.parsing.test.ts
@@ -392,11 +392,9 @@ describe("parseCertsReport - multi-version fixtures", () => {
 	});
 
 	it("should return null for app without any certificate", () => {
-		const stdout = [
-			"=====> myapp certs information",
-			"       No SSL certificate configured",
-		].join("\n");
+		const stdout = ["=====> myapp certs information", "       No SSL certificate configured"].join(
+			"\n"
+		);
 		expect(parseCertsReport(stdout)).toBeNull();
 	});
 });
-

--- a/server/lib/websocket.test.ts
+++ b/server/lib/websocket.test.ts
@@ -505,11 +505,7 @@ describe("event stream endpoint", () => {
 	it("should reject /api/events/stream with invalid token", () => {
 		vi.mocked(verifyToken).mockReturnValue(null);
 		const socket = makeSocket();
-		upgradeHandler(
-			makeReq("/api/events/stream", "session=bad-token"),
-			socket,
-			Buffer.alloc(0)
-		);
+		upgradeHandler(makeReq("/api/events/stream", "session=bad-token"), socket, Buffer.alloc(0));
 		expect((socket as unknown as { write: (d: string) => void }).write).toHaveBeenCalledWith(
 			"HTTP/1.1 401 Unauthorized\r\n\r\n"
 		);
@@ -525,7 +521,7 @@ describe("event stream endpoint", () => {
 	it("should send app event to connected WebSocket client", () => {
 		expect(mockWss.on).toHaveBeenCalledWith("connection", expect.any(Function));
 
-		const connectionHandler = mockWss.on.mock.calls.find(call => call[0] === "connection")?.[1];
+		const connectionHandler = mockWss.on.mock.calls.find((call) => call[0] === "connection")?.[1];
 
 		const mockWs = {
 			isAlive: true,
@@ -545,7 +541,9 @@ describe("event stream endpoint", () => {
 			configurable: true,
 		});
 
-		const mockReq = makeReq("/api/events/stream", "session=valid-token") as http.IncomingMessage & { isEventStream?: boolean };
+		const mockReq = makeReq("/api/events/stream", "session=valid-token") as http.IncomingMessage & {
+			isEventStream?: boolean;
+		};
 		mockReq.isEventStream = true;
 
 		connectionHandler(mockWs, mockReq);
@@ -553,7 +551,11 @@ describe("event stream endpoint", () => {
 		expect(vi.mocked(subscribeToAppEvents)).toHaveBeenCalled();
 		const capturedListener = vi.mocked(subscribeToAppEvents).mock.calls[0][0];
 
-		const testEvent = { type: "app:restart", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" };
+		const testEvent = {
+			type: "app:restart",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		};
 		capturedListener(testEvent);
 
 		expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify(testEvent));

--- a/server/routes/apps.test.ts
+++ b/server/routes/apps.test.ts
@@ -38,7 +38,16 @@ vi.mock("../lib/app-events.js", () => ({
 	broadcastAppEvent: vi.fn(),
 }));
 
-import { createApp, destroyApp, restartApp, stopApp, startApp, rebuildApp, scaleApp, unlockApp } from "../lib/apps.js";
+import {
+	createApp,
+	destroyApp,
+	restartApp,
+	stopApp,
+	startApp,
+	rebuildApp,
+	scaleApp,
+	unlockApp,
+} from "../lib/apps.js";
 import { broadcastAppEvent } from "../lib/app-events.js";
 import { registerAppRoutes } from "./apps.js";
 

--- a/server/routes/databases.ts
+++ b/server/routes/databases.ts
@@ -110,13 +110,28 @@ export function registerDatabaseRoutes(app: express.Application): void {
 
 	app.post("/api/databases/:name/link", authMiddleware, requireOperator, async (req, res) => {
 		const name = getParam(req.params, "name");
-		const { plugin, app } = req.body;
+		const { plugin, app, alias } = req.body;
+
+		// Validate alias if provided (consistent with linkDatabase validation)
+		if (alias) {
+			const trimmedAlias = alias.trim();
+			const sanitizedAlias = trimmedAlias.replace(/[^a-zA-Z0-9_]/g, "");
+			if (sanitizedAlias !== trimmedAlias) {
+				res.status(400).json({
+					error:
+						"Alias contains invalid characters (only letters, numbers, and underscores allowed)",
+					command: "",
+					exitCode: 400,
+				});
+				return;
+			}
+		}
 
 		if (isSSERequest(req)) {
 			await streamAction(
 				req,
 				res,
-				DokkuCommands.dbLink(plugin, name, app),
+				DokkuCommands.dbLink(plugin, name, app, alias),
 				"database:link",
 				name,
 				60000
@@ -124,14 +139,16 @@ export function registerDatabaseRoutes(app: express.Application): void {
 			return;
 		}
 
-		const result = await linkDatabase(plugin, name, app);
+		const result = await linkDatabase(plugin, name, app, alias);
 
 		if (result.exitCode === 0) {
-			safeAuditLog(req, "database:link", name, { plugin, database: name, app });
+			safeAuditLog(req, "database:link", name, { plugin, database: name, app, alias });
 		}
 
 		clearPrefix("databases:");
-		res.json(result);
+		// Return proper HTTP status code based on exitCode
+		const statusCode = result.exitCode >= 400 ? result.exitCode : result.exitCode !== 0 ? 500 : 200;
+		res.status(statusCode).json(result);
 	});
 
 	app.post("/api/databases/:name/unlink", authMiddleware, requireOperator, async (req, res) => {

--- a/server/routes/databases.ts
+++ b/server/routes/databases.ts
@@ -112,9 +112,9 @@ export function registerDatabaseRoutes(app: express.Application): void {
 		const name = getParam(req.params, "name");
 		const { plugin, app, alias } = req.body;
 
-		// Validate alias if provided (consistent with linkDatabase validation)
-		if (alias) {
-			const trimmedAlias = alias.trim();
+		// Validate and trim alias if provided (consistent with linkDatabase validation)
+		const trimmedAlias = alias ? alias.trim() : undefined;
+		if (trimmedAlias) {
 			const sanitizedAlias = trimmedAlias.replace(/[^a-zA-Z0-9_]/g, "");
 			if (sanitizedAlias !== trimmedAlias) {
 				res.status(400).json({
@@ -131,7 +131,7 @@ export function registerDatabaseRoutes(app: express.Application): void {
 			await streamAction(
 				req,
 				res,
-				DokkuCommands.dbLink(plugin, name, app, alias),
+				DokkuCommands.dbLink(plugin, name, app, trimmedAlias),
 				"database:link",
 				name,
 				60000
@@ -139,10 +139,10 @@ export function registerDatabaseRoutes(app: express.Application): void {
 			return;
 		}
 
-		const result = await linkDatabase(plugin, name, app, alias);
+		const result = await linkDatabase(plugin, name, app, trimmedAlias);
 
 		if (result.exitCode === 0) {
-			safeAuditLog(req, "database:link", name, { plugin, database: name, app, alias });
+			safeAuditLog(req, "database:link", name, { plugin, database: name, app, alias: trimmedAlias });
 		}
 
 		clearPrefix("databases:");


### PR DESCRIPTION
## What
Add ability to link/unlink databases to Dokku apps from the UI.

## Why
Users currently cannot associate databases with their apps through the Docklight interface. They need to use CLI commands directly, which is not user-friendly.

## How
- Add `link` and `unlink` database commands in `server/lib/databases.ts`
- Add new database-related routes for linking/unlinking
- Update UI in `Databases.tsx` to show linked apps and provide link/unlink actions
- Add parsing for database links in command output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database linking supports an optional alias for linked databases (validated); alias input clears after successful link.
  * Link dialog confirm button text during submission is now customizable.

* **Behavior Changes**
  * Link operations return more accurate HTTP status codes reflecting outcomes.
  * App linking options better filter displayed apps by name.

* **Tests**
  * Added tests covering linking with an alias.

* **Style**
  * Formatting and refactors across tests and server code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->