### PR TITLE
feat: add one-line install script for fresh VPS deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,33 @@ Docklight is designed to run on the same VPS as Dokku.
 
 ### Installation
 
-#### Deploy to Dokku (Recommended)
+#### One-line install (fresh VPS — installs Dokku + Docklight)
+
+On a fresh Ubuntu/Debian VPS, run as root:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/install.sh | sudo bash
+```
+
+With a custom domain and HTTPS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/install.sh \
+  | sudo DOMAIN=docklight.example.com ENABLE_HTTPS=1 LETSENCRYPT_EMAIL=you@example.com bash
+```
+
+The installer will:
+
+1. Install Dokku (if not already present)
+2. Create the `docklight` app and persistent storage
+3. Configure the container → host SSH bridge for the Dokku CLI
+4. Generate a `JWT_SECRET`
+5. Deploy Docklight from this repo
+6. Create an initial admin user and print the password
+
+Available env vars: `APP_NAME`, `DOMAIN`, `REPO_URL`, `BRANCH`, `DOKKU_VERSION`, `ENABLE_HTTPS`, `LETSENCRYPT_EMAIL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`.
+
+#### Manual deploy to existing Dokku
 
 ```bash
 # On your Dokku server

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,14 @@
 
 Step-by-step guide to deploy Docklight on your Dokku server.
 
+## TL;DR — One-line install on a fresh VPS
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/install.sh | sudo bash
+```
+
+This installs Dokku (if needed), creates the `docklight` app, wires up persistent storage and the container → host SSH bridge, deploys from this repo, and prints the generated admin password. See [`scripts/install.sh`](../scripts/install.sh) for env-var options (`DOMAIN`, `ENABLE_HTTPS`, `LETSENCRYPT_EMAIL`, …). The rest of this guide covers the manual flow.
+
 ## Prerequisites
 
 - A VPS with [Dokku](https://dokku.com/docs/getting-started/installation/) installed

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,13 @@ require_root() {
 
 detect_ip() {
   local ip
+  # 1. External lookup (most reliable for the publicly-routable address)
   ip="$(curl -fsSL --max-time 5 https://api.ipify.org 2>/dev/null || true)"
+  # 2. Routable source address (avoids picking an RFC1918 interface)
+  if [[ -z "${ip}" ]] && command -v ip >/dev/null 2>&1; then
+    ip="$(ip route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')"
+  fi
+  # 3. Last resort
   if [[ -z "${ip}" ]]; then
     ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
   fi
@@ -76,7 +82,7 @@ fi
 # ---------- 1. install Dokku ----------
 if ! command -v dokku >/dev/null 2>&1; then
   log "Installing Dokku ${DOKKU_VERSION} (this can take a few minutes)..."
-  wget -qO /tmp/bootstrap.sh "https://dokku.com/install/${DOKKU_VERSION}/bootstrap.sh"
+  curl -fsSL -o /tmp/bootstrap.sh "https://dokku.com/install/${DOKKU_VERSION}/bootstrap.sh"
   DOKKU_TAG="${DOKKU_VERSION}" bash /tmp/bootstrap.sh
   rm -f /tmp/bootstrap.sh
 else
@@ -104,17 +110,15 @@ KEY_PATH="${DOKKU_HOME}/.ssh/docklight"
 if [[ ! -f "${KEY_PATH}" ]]; then
   log "Generating dedicated SSH key for Docklight (${KEY_PATH})"
   sudo -u dokku mkdir -p "${DOKKU_HOME}/.ssh"
+  sudo -u dokku chmod 700 "${DOKKU_HOME}/.ssh"
   sudo -u dokku ssh-keygen -t ed25519 -N "" -f "${KEY_PATH}" -C "docklight@${SERVER_IP}"
   sudo -u dokku sh -c "cat '${KEY_PATH}.pub' >> '${DOKKU_HOME}/.ssh/authorized_keys'"
   sudo -u dokku chmod 600 "${DOKKU_HOME}/.ssh/authorized_keys"
 fi
 
-# Pre-populate known_hosts so the container won't fail on first SSH
-sudo -u dokku touch "${DOKKU_HOME}/.ssh/known_hosts"
-if ! sudo -u dokku grep -q "${SERVER_IP}" "${DOKKU_HOME}/.ssh/known_hosts" 2>/dev/null; then
-  log "Adding ${SERVER_IP} to dokku user known_hosts"
-  ssh-keyscan -H "${SERVER_IP}" 2>/dev/null | sudo -u dokku tee -a "${DOKKU_HOME}/.ssh/known_hosts" >/dev/null
-fi
+# Note: the container does not need a known_hosts file. The server defaults
+# DOCKLIGHT_DOKKU_SSH_OPTS to "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+# (see server/lib/executor.ts), so host key verification is skipped inside the container.
 
 # ---------- 4. persistent storage ----------
 STORAGE_DIR="/var/lib/dokku/data/storage/${APP_NAME}"
@@ -164,32 +168,43 @@ else
 fi
 
 log "Creating initial admin user '${ADMIN_USERNAME}'"
-if ! dokku enter "${APP_NAME}" web sh -c \
-      "node server/dist/createUser.js '${ADMIN_USERNAME}' '${ADMIN_PASSWORD}'" 2>&1; then
+# Use `dokku run` (transient container) so we don't depend on the web container
+# being up yet, and pass credentials as positional args to avoid shell injection.
+if ! dokku run "${APP_NAME}" \
+      node server/dist/createUser.js "${ADMIN_USERNAME}" "${ADMIN_PASSWORD}" 2>&1; then
   warn "Could not create admin user automatically — create one with:"
-  warn "  dokku enter ${APP_NAME} web sh -c 'node server/dist/createUser.js admin <password>'"
+  warn "  dokku run ${APP_NAME} node server/dist/createUser.js admin '<password>'"
   GENERATED_PW=0
 fi
 
 # ---------- 9. (optional) HTTPS ----------
+HTTPS_ENABLED=0
 if [[ "${ENABLE_HTTPS}" == "1" ]]; then
   if [[ -z "${LETSENCRYPT_EMAIL}" ]]; then
     warn "ENABLE_HTTPS=1 but LETSENCRYPT_EMAIL is not set — skipping SSL"
   else
     log "Installing dokku-letsencrypt plugin (if missing)"
     if ! dokku plugin:list | grep -q letsencrypt; then
-      dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
+      dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git \
+        || warn "Could not install dokku-letsencrypt plugin"
     fi
-    dokku letsencrypt:set "${APP_NAME}" email "${LETSENCRYPT_EMAIL}"
-    log "Enabling HTTPS via Let's Encrypt"
-    dokku letsencrypt:enable "${APP_NAME}" || warn "Let's Encrypt failed — make sure DNS points to ${SERVER_IP}"
-    dokku letsencrypt:cron-job --add || true
+    if dokku plugin:list | grep -q letsencrypt; then
+      dokku letsencrypt:set "${APP_NAME}" email "${LETSENCRYPT_EMAIL}" \
+        || warn "Could not configure Let's Encrypt email"
+      log "Enabling HTTPS via Let's Encrypt"
+      if dokku letsencrypt:enable "${APP_NAME}"; then
+        HTTPS_ENABLED=1
+        dokku letsencrypt:cron-job --add || true
+      else
+        warn "Let's Encrypt failed — make sure DNS for ${DOMAIN} points to ${SERVER_IP}"
+      fi
+    fi
   fi
 fi
 
 # ---------- done ----------
 URL_SCHEME="http"
-[[ "${ENABLE_HTTPS}" == "1" ]] && URL_SCHEME="https"
+[[ "${HTTPS_ENABLED}" == "1" ]] && URL_SCHEME="https"
 
 cat <<EOF
 
@@ -224,8 +239,8 @@ cat <<EOF
     dokku enter ${APP_NAME} web sh         # shell into container
 
   Reset password:
-    dokku enter ${APP_NAME} web sh -c \\
-      "node server/dist/createUser.js ${ADMIN_USERNAME} <new-password>"
+    dokku run ${APP_NAME} \\
+      node server/dist/createUser.js ${ADMIN_USERNAME} '<new-password>'
 
 EOF
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Docklight one-line installer
+#
+# Installs Dokku (if missing) and deploys Docklight on a fresh Ubuntu/Debian VPS.
+#
+# Usage (run as root on the VPS):
+#   curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/install.sh | sudo bash
+#
+# With options:
+#   curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/install.sh \
+#     | sudo DOMAIN=docklight.example.com bash
+#
+# Environment variables (all optional):
+#   APP_NAME       Dokku app name                       (default: docklight)
+#   DOMAIN         Custom domain for the app            (default: <ip>.sslip.io)
+#   REPO_URL       Git repo to deploy                   (default: https://github.com/jellydn/docklight.git)
+#   BRANCH         Branch to deploy                     (default: main)
+#   DOKKU_VERSION  Dokku version to install             (default: v0.35.20)
+#   ENABLE_HTTPS   Run letsencrypt after deploy (1/0)   (default: 0; requires DOMAIN)
+#   LETSENCRYPT_EMAIL  Email for Let's Encrypt          (required if ENABLE_HTTPS=1)
+#   ADMIN_USERNAME Initial admin username               (default: admin)
+#   ADMIN_PASSWORD Initial admin password               (default: auto-generated)
+
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-docklight}"
+DOMAIN="${DOMAIN:-}"
+REPO_URL="${REPO_URL:-https://github.com/jellydn/docklight.git}"
+BRANCH="${BRANCH:-main}"
+DOKKU_VERSION="${DOKKU_VERSION:-v0.35.20}"
+ENABLE_HTTPS="${ENABLE_HTTPS:-0}"
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
+
+# ---------- helpers ----------
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+err()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    err "This installer must be run as root (try: sudo bash)"
+  fi
+}
+
+detect_ip() {
+  local ip
+  ip="$(curl -fsSL --max-time 5 https://api.ipify.org 2>/dev/null || true)"
+  if [[ -z "${ip}" ]]; then
+    ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  fi
+  [[ -n "${ip}" ]] || err "Could not detect server IP"
+  printf '%s' "${ip}"
+}
+
+# ---------- preflight ----------
+require_root
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v openssl >/dev/null 2>&1; then
+  log "Installing base packages (curl, openssl, ca-certificates)..."
+  apt-get update -y
+  apt-get install -y curl openssl ca-certificates
+fi
+
+SERVER_IP="$(detect_ip)"
+log "Detected server IP: ${SERVER_IP}"
+
+# Default domain: <ip>.sslip.io (works with no DNS setup)
+if [[ -z "${DOMAIN}" ]]; then
+  DOMAIN="${APP_NAME}.${SERVER_IP}.sslip.io"
+  log "No DOMAIN provided — using ${DOMAIN}"
+fi
+
+# ---------- 1. install Dokku ----------
+if ! command -v dokku >/dev/null 2>&1; then
+  log "Installing Dokku ${DOKKU_VERSION} (this can take a few minutes)..."
+  wget -qO /tmp/bootstrap.sh "https://dokku.com/install/${DOKKU_VERSION}/bootstrap.sh"
+  DOKKU_TAG="${DOKKU_VERSION}" bash /tmp/bootstrap.sh
+  rm -f /tmp/bootstrap.sh
+else
+  log "Dokku already installed: $(dokku version || echo unknown)"
+fi
+
+# Make sure the global domain is set so Dokku generates nice URLs
+if ! dokku domains:report --global 2>/dev/null | grep -q "Domains global vhosts:.*[a-z0-9]"; then
+  log "Setting Dokku global domain to ${SERVER_IP}.sslip.io"
+  dokku domains:set-global "${SERVER_IP}.sslip.io"
+fi
+
+# ---------- 2. create app ----------
+if dokku apps:exists "${APP_NAME}" >/dev/null 2>&1; then
+  log "App '${APP_NAME}' already exists — reusing"
+else
+  log "Creating Dokku app '${APP_NAME}'"
+  dokku apps:create "${APP_NAME}"
+fi
+
+# ---------- 3. SSH key for container -> host Dokku CLI ----------
+DOKKU_HOME="/home/dokku"
+KEY_PATH="${DOKKU_HOME}/.ssh/docklight"
+
+if [[ ! -f "${KEY_PATH}" ]]; then
+  log "Generating dedicated SSH key for Docklight (${KEY_PATH})"
+  sudo -u dokku mkdir -p "${DOKKU_HOME}/.ssh"
+  sudo -u dokku ssh-keygen -t ed25519 -N "" -f "${KEY_PATH}" -C "docklight@${SERVER_IP}"
+  sudo -u dokku sh -c "cat '${KEY_PATH}.pub' >> '${DOKKU_HOME}/.ssh/authorized_keys'"
+  sudo -u dokku chmod 600 "${DOKKU_HOME}/.ssh/authorized_keys"
+fi
+
+# Pre-populate known_hosts so the container won't fail on first SSH
+sudo -u dokku touch "${DOKKU_HOME}/.ssh/known_hosts"
+if ! sudo -u dokku grep -q "${SERVER_IP}" "${DOKKU_HOME}/.ssh/known_hosts" 2>/dev/null; then
+  log "Adding ${SERVER_IP} to dokku user known_hosts"
+  ssh-keyscan -H "${SERVER_IP}" 2>/dev/null | sudo -u dokku tee -a "${DOKKU_HOME}/.ssh/known_hosts" >/dev/null
+fi
+
+# ---------- 4. persistent storage ----------
+STORAGE_DIR="/var/lib/dokku/data/storage/${APP_NAME}"
+mkdir -p "${STORAGE_DIR}"
+chown -R 32767:32767 "${STORAGE_DIR}" 2>/dev/null || chown -R dokku:dokku "${STORAGE_DIR}"
+
+storage_mounted() { dokku storage:list "${APP_NAME}" 2>/dev/null | grep -Fq "$1"; }
+
+if ! storage_mounted ":/app/data"; then
+  log "Mounting persistent data volume"
+  dokku storage:mount "${APP_NAME}" "${STORAGE_DIR}:/app/data"
+fi
+
+if ! storage_mounted ":/app/.ssh/id_ed25519"; then
+  log "Mounting SSH key into container"
+  dokku storage:mount "${APP_NAME}" "${KEY_PATH}:/app/.ssh/id_ed25519"
+fi
+
+# ---------- 5. config ----------
+get_config() { dokku config:get "${APP_NAME}" "$1" 2>/dev/null || true; }
+
+if [[ -z "$(get_config JWT_SECRET)" ]]; then
+  log "Generating JWT_SECRET"
+  dokku config:set --no-restart "${APP_NAME}" JWT_SECRET="$(openssl rand -base64 48)"
+fi
+
+log "Setting Dokku SSH bridge config"
+dokku config:set --no-restart "${APP_NAME}" \
+  DOCKLIGHT_DOKKU_SSH_TARGET="dokku@${SERVER_IP}" \
+  DOCKLIGHT_DOKKU_SSH_KEY_PATH=/app/.ssh/id_ed25519 \
+  DOCKLIGHT_DB_PATH=/app/data/docklight.db
+
+# ---------- 6. domain ----------
+log "Setting domain: ${DOMAIN}"
+dokku domains:set "${APP_NAME}" "${DOMAIN}"
+
+# ---------- 7. deploy ----------
+log "Deploying ${APP_NAME} from ${REPO_URL} (branch: ${BRANCH})"
+dokku git:sync --build "${APP_NAME}" "${REPO_URL}" "${BRANCH}"
+
+# ---------- 8. initial admin user ----------
+if [[ -z "${ADMIN_PASSWORD}" ]]; then
+  ADMIN_PASSWORD="$(openssl rand -base64 18 | tr -d '/+=' | cut -c1-20)"
+  GENERATED_PW=1
+else
+  GENERATED_PW=0
+fi
+
+log "Creating initial admin user '${ADMIN_USERNAME}'"
+if ! dokku enter "${APP_NAME}" web sh -c \
+      "node server/dist/createUser.js '${ADMIN_USERNAME}' '${ADMIN_PASSWORD}'" 2>&1; then
+  warn "Could not create admin user automatically — create one with:"
+  warn "  dokku enter ${APP_NAME} web sh -c 'node server/dist/createUser.js admin <password>'"
+  GENERATED_PW=0
+fi
+
+# ---------- 9. (optional) HTTPS ----------
+if [[ "${ENABLE_HTTPS}" == "1" ]]; then
+  if [[ -z "${LETSENCRYPT_EMAIL}" ]]; then
+    warn "ENABLE_HTTPS=1 but LETSENCRYPT_EMAIL is not set — skipping SSL"
+  else
+    log "Installing dokku-letsencrypt plugin (if missing)"
+    if ! dokku plugin:list | grep -q letsencrypt; then
+      dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
+    fi
+    dokku letsencrypt:set "${APP_NAME}" email "${LETSENCRYPT_EMAIL}"
+    log "Enabling HTTPS via Let's Encrypt"
+    dokku letsencrypt:enable "${APP_NAME}" || warn "Let's Encrypt failed — make sure DNS points to ${SERVER_IP}"
+    dokku letsencrypt:cron-job --add || true
+  fi
+fi
+
+# ---------- done ----------
+URL_SCHEME="http"
+[[ "${ENABLE_HTTPS}" == "1" ]] && URL_SCHEME="https"
+
+cat <<EOF
+
+============================================================
+  ✅ Docklight is installed!
+============================================================
+
+  URL:        ${URL_SCHEME}://${DOMAIN}
+  App name:   ${APP_NAME}
+  Server IP:  ${SERVER_IP}
+
+EOF
+
+if [[ "${GENERATED_PW:-0}" == "1" ]]; then
+  cat <<EOF
+  Login:
+    username: ${ADMIN_USERNAME}
+    password: ${ADMIN_PASSWORD}
+
+  >>> SAVE THIS PASSWORD — it is shown only once. <<<
+
+EOF
+else
+  echo "  Login with the admin credentials you provided."
+  echo
+fi
+
+cat <<EOF
+  Useful commands (run on the server):
+    dokku logs ${APP_NAME} -t              # tail logs
+    dokku ps:restart ${APP_NAME}           # restart
+    dokku enter ${APP_NAME} web sh         # shell into container
+
+  Reset password:
+    dokku enter ${APP_NAME} web sh -c \\
+      "node server/dist/createUser.js ${ADMIN_USERNAME} <new-password>"
+
+EOF
+
+if [[ "${ENABLE_HTTPS}" != "1" ]]; then
+  cat <<EOF
+  To enable HTTPS later:
+    dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
+    dokku letsencrypt:set ${APP_NAME} email you@example.com
+    dokku letsencrypt:enable ${APP_NAME}
+
+EOF
+fi

--- a/server/lib/app-events.test.ts
+++ b/server/lib/app-events.test.ts
@@ -35,7 +35,11 @@ describe("app-events", () => {
 		const unsubscribe = subscribeToAppEvents(listener);
 		unsubscribe();
 
-		broadcastAppEvent({ type: "app:stop", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" });
+		broadcastAppEvent({
+			type: "app:stop",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		});
 
 		expect(listener).not.toHaveBeenCalled();
 	});
@@ -68,7 +72,11 @@ describe("app-events", () => {
 
 		unsub1();
 
-		broadcastAppEvent({ type: "app:scale", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" });
+		broadcastAppEvent({
+			type: "app:scale",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		});
 
 		expect(listener1).not.toHaveBeenCalled();
 		expect(listener2).toHaveBeenCalled();

--- a/server/lib/app-events.ts
+++ b/server/lib/app-events.ts
@@ -20,7 +20,10 @@ export function broadcastAppEvent(event: AppEvent): void {
 		try {
 			listener(event);
 		} catch (err) {
-			logger.error({ err, eventType: event.type, appName: event.appName }, "Error in app event listener");
+			logger.error(
+				{ err, eventType: event.type, appName: event.appName },
+				"Error in app event listener"
+			);
 		}
 	}
 }

--- a/server/lib/apps.ts
+++ b/server/lib/apps.ts
@@ -191,7 +191,10 @@ export function parseStatus(stdout: string): "running" | "stopped" {
 	}
 
 	if (sawAnyContent) {
-		logger.warn({ stdout }, "parseStatus: no recognizable status format found, defaulting to stopped");
+		logger.warn(
+			{ stdout },
+			"parseStatus: no recognizable status format found, defaulting to stopped"
+		);
 	}
 
 	return "stopped";
@@ -256,8 +259,7 @@ export function parseDomains(stdout: string): string[] {
 	}
 
 	if (domains.size === 0 && stdout.trim()) {
-		const hasDomainsContent =
-			/domains/i.test(stdout) || /vhost/i.test(stdout);
+		const hasDomainsContent = /domains/i.test(stdout) || /vhost/i.test(stdout);
 		if (hasDomainsContent && !enabledLine) {
 			logger.warn(
 				{ stdout },

--- a/server/lib/databases.parsing.test.ts
+++ b/server/lib/databases.parsing.test.ts
@@ -3,21 +3,12 @@ import { parseInstalledPlugins, parseLinkedApps } from "./databases.js";
 
 describe("parseInstalledPlugins", () => {
 	it("should detect dokku-postgres from plugin list", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-postgres",
-			"dokku-builder-dockerfile",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-postgres", "dokku-builder-dockerfile"].join("\n");
 		expect(parseInstalledPlugins(output)).toEqual(["postgres"]);
 	});
 
 	it("should detect multiple plugins", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-postgres",
-			"dokku-redis",
-			"dokku-mysql",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-postgres", "dokku-redis", "dokku-mysql"].join("\n");
 		expect(parseInstalledPlugins(output)).toContain("postgres");
 		expect(parseInstalledPlugins(output)).toContain("redis");
 		expect(parseInstalledPlugins(output)).toContain("mysql");
@@ -40,11 +31,9 @@ describe("parseInstalledPlugins", () => {
 	});
 
 	it("should return empty array when no supported plugins found", () => {
-		const output = [
-			"00_dokku-standard",
-			"dokku-builder-dockerfile",
-			"dokku-letsencrypt",
-		].join("\n");
+		const output = ["00_dokku-standard", "dokku-builder-dockerfile", "dokku-letsencrypt"].join(
+			"\n"
+		);
 		expect(parseInstalledPlugins(output)).toEqual([]);
 	});
 
@@ -88,11 +77,7 @@ describe("parseInstalledPlugins", () => {
 
 describe("parseLinkedApps", () => {
 	it("should parse multi-line linked apps from Dokku 0.30.x links output", () => {
-		const output = [
-			"=====> main-db linked apps",
-			"api",
-			"worker",
-		].join("\n");
+		const output = ["=====> main-db linked apps", "api", "worker"].join("\n");
 		expect(parseLinkedApps(output)).toEqual(["api", "worker"]);
 	});
 

--- a/server/lib/ports.parsing.test.ts
+++ b/server/lib/ports.parsing.test.ts
@@ -40,11 +40,7 @@ describe("parsePortMappings", () => {
 	});
 
 	it("should parse older Dokku proxy:ports line-per-mapping format", () => {
-		const stdout = [
-			"=====> my-app proxy ports",
-			"http:80:5000",
-			"https:443:5000",
-		].join("\n");
+		const stdout = ["=====> my-app proxy ports", "http:80:5000", "https:443:5000"].join("\n");
 		expect(parsePortMappings(stdout)).toEqual([
 			{ scheme: "http", hostPort: 80, containerPort: 5000 },
 			{ scheme: "https", hostPort: 443, containerPort: 5000 },
@@ -52,10 +48,7 @@ describe("parsePortMappings", () => {
 	});
 
 	it("should parse Dokku 0.30.x proxy:ports single port per line", () => {
-		const stdout = [
-			"=====> my-app proxy information",
-			"       http:3000:3000",
-		].join("\n");
+		const stdout = ["=====> my-app proxy information", "       http:3000:3000"].join("\n");
 		expect(parsePortMappings(stdout)).toEqual([
 			{ scheme: "http", hostPort: 3000, containerPort: 3000 },
 		]);

--- a/server/lib/ssl.parsing.test.ts
+++ b/server/lib/ssl.parsing.test.ts
@@ -392,11 +392,9 @@ describe("parseCertsReport - multi-version fixtures", () => {
 	});
 
 	it("should return null for app without any certificate", () => {
-		const stdout = [
-			"=====> myapp certs information",
-			"       No SSL certificate configured",
-		].join("\n");
+		const stdout = ["=====> myapp certs information", "       No SSL certificate configured"].join(
+			"\n"
+		);
 		expect(parseCertsReport(stdout)).toBeNull();
 	});
 });
-

--- a/server/lib/websocket.test.ts
+++ b/server/lib/websocket.test.ts
@@ -505,11 +505,7 @@ describe("event stream endpoint", () => {
 	it("should reject /api/events/stream with invalid token", () => {
 		vi.mocked(verifyToken).mockReturnValue(null);
 		const socket = makeSocket();
-		upgradeHandler(
-			makeReq("/api/events/stream", "session=bad-token"),
-			socket,
-			Buffer.alloc(0)
-		);
+		upgradeHandler(makeReq("/api/events/stream", "session=bad-token"), socket, Buffer.alloc(0));
 		expect((socket as unknown as { write: (d: string) => void }).write).toHaveBeenCalledWith(
 			"HTTP/1.1 401 Unauthorized\r\n\r\n"
 		);
@@ -525,7 +521,7 @@ describe("event stream endpoint", () => {
 	it("should send app event to connected WebSocket client", () => {
 		expect(mockWss.on).toHaveBeenCalledWith("connection", expect.any(Function));
 
-		const connectionHandler = mockWss.on.mock.calls.find(call => call[0] === "connection")?.[1];
+		const connectionHandler = mockWss.on.mock.calls.find((call) => call[0] === "connection")?.[1];
 
 		const mockWs = {
 			isAlive: true,
@@ -545,7 +541,9 @@ describe("event stream endpoint", () => {
 			configurable: true,
 		});
 
-		const mockReq = makeReq("/api/events/stream", "session=valid-token") as http.IncomingMessage & { isEventStream?: boolean };
+		const mockReq = makeReq("/api/events/stream", "session=valid-token") as http.IncomingMessage & {
+			isEventStream?: boolean;
+		};
 		mockReq.isEventStream = true;
 
 		connectionHandler(mockWs, mockReq);
@@ -553,7 +551,11 @@ describe("event stream endpoint", () => {
 		expect(vi.mocked(subscribeToAppEvents)).toHaveBeenCalled();
 		const capturedListener = vi.mocked(subscribeToAppEvents).mock.calls[0][0];
 
-		const testEvent = { type: "app:restart", appName: "my-app", timestamp: "2024-01-01T00:00:00.000Z" };
+		const testEvent = {
+			type: "app:restart",
+			appName: "my-app",
+			timestamp: "2024-01-01T00:00:00.000Z",
+		};
 		capturedListener(testEvent);
 
 		expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify(testEvent));

--- a/server/routes/apps.test.ts
+++ b/server/routes/apps.test.ts
@@ -38,7 +38,16 @@ vi.mock("../lib/app-events.js", () => ({
 	broadcastAppEvent: vi.fn(),
 }));
 
-import { createApp, destroyApp, restartApp, stopApp, startApp, rebuildApp, scaleApp, unlockApp } from "../lib/apps.js";
+import {
+	createApp,
+	destroyApp,
+	restartApp,
+	stopApp,
+	startApp,
+	rebuildApp,
+	scaleApp,
+	unlockApp,
+} from "../lib/apps.js";
 import { broadcastAppEvent } from "../lib/app-events.js";
 import { registerAppRoutes } from "./apps.js";
 


### PR DESCRIPTION
## What

Adds a one-line install script (`scripts/install.sh`) for deploying Docklight on a fresh Ubuntu/Debian VPS, along with documentation in `README.md` and `docs/deployment.md`. Also includes minor formatting fixes across several test and source files.

## Why

Users need a zero-friction way to get Docklight running on a new VPS. Previously the setup required manual Dokku installation, app creation, SSH key setup, persistent storage mounting, config, and deployment — 7+ steps. The one-liner handles all of this automatically, including Dokku installation if absent.

## How

- A bash script (`scripts/install.sh`, ~240 lines) that runs as root and chains: Dokku install → app creation → SSH key generation for container→host bridge → persistent storage → JWT secret + Dokku config → domain setting → `git:sync` deploy → initial admin user creation → optional Let's Encrypt
- All steps are idempotent (guarded with existence checks) and configurable via env vars (`DOMAIN`, `APP_NAME`, `BRANCH`, `ENABLE_HTTPS`, `LETSENCRYPT_EMAIL`, etc.)
- Documentation added at the top of `README.md`'s install section and a TL;DR in `docs/deployment.md`
- Incidental formatting fixes from biome — no behavioral changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-line installer script for deploying to a fresh VPS, which automatically installs Dokku, sets up the Docklight app, configures SSH bridging, generates security credentials, and creates an initial admin user.

* **Documentation**
  * Updated deployment documentation with a quick-start TL;DR section featuring the simplified installation command.
  * Added new section for manual deployment to existing Dokku instances.

* **Chores**
  * Improved error logging structure and test code formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->