### PR TITLE
feat(dashboard): add purge build caches action for disk recovery (#127)

### DIFF
--- a/.changeset/purge-build-caches.md
+++ b/.changeset/purge-build-caches.md
@@ -1,0 +1,5 @@
+---
+"docklight-server": patch
+---
+
+feat: add dashboard purge build caches action for disk recovery

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Docklight is designed to run on the same VPS as Dokku.
 ## ✨ Features
 
 - Dashboard with app status, domains, last deploy, and VPS health (CPU, memory, disk) with warning/critical thresholds.
-- One-click `dokku cleanup` from the dashboard for operators and admins (removes unused containers and images, not volumes).
+- One-click server cleanup from the dashboard for operators and admins: **Clean unused** runs `dokku cleanup` (removes unused containers and images); **Purge build caches** runs `dokku repo:purge-cache` across all apps when disk is warning or critical (does not remove volumes or run `repo:gc`).
 - App management: restart, rebuild, scale, config vars, and domains.
 - Real-time app status updates via WebSocket push notifications.
 - Live app logs over WebSocket.
@@ -253,7 +253,7 @@ docklight/
 | Databases | `plugin:list`, `<plugin>:list`, `<plugin>:links`, `<plugin>:create`, `<plugin>:link`, `<plugin>:unlink`, `<plugin>:destroy`                   |
 | Plugins   | `plugin:list`, `plugin:install`, `plugin:enable`, `plugin:disable`, `plugin:uninstall`                                                        |
 | SSL       | `letsencrypt:report`, `letsencrypt:ls`, `certs:report`, `letsencrypt:set <app> email <email>`, `letsencrypt:enable`, `letsencrypt:auto-renew` |
-| Server    | `cleanup`                                                                                                                                     |
+| Server    | `cleanup`, `repo:purge-cache`                                                                                                                 |
 
 ## 🤝 Contributing
 

--- a/client/src/components/ServerHealthCard.tsx
+++ b/client/src/components/ServerHealthCard.tsx
@@ -63,21 +63,34 @@ interface ServerHealthCardProps {
 	health: ServerHealth;
 	canModify: boolean;
 	cleanupSubmitting: boolean;
+	purgeSubmitting: boolean;
 	onCleanupConfirm: () => void;
+	onPurgeConfirm: () => void;
 }
 
 export function ServerHealthCard({
 	health,
 	canModify,
 	cleanupSubmitting,
+	purgeSubmitting,
 	onCleanupConfirm,
+	onPurgeConfirm,
 }: ServerHealthCardProps) {
 	const [cleanupDialogOpen, setCleanupDialogOpen] = useState(false);
+	const [purgeDialogOpen, setPurgeDialogOpen] = useState(false);
 	const statusPresentation = HEALTH_STATUS_PRESENTATION[health.status];
+	const showPurgeButton =
+		canModify &&
+		(health.resources.disk.status === "warning" || health.resources.disk.status === "critical");
 
 	const handleCleanupConfirm = () => {
 		onCleanupConfirm();
 		setCleanupDialogOpen(false);
+	};
+
+	const handlePurgeConfirm = () => {
+		onPurgeConfirm();
+		setPurgeDialogOpen(false);
 	};
 
 	return (
@@ -86,14 +99,26 @@ export function ServerHealthCard({
 				<CardHeader className="flex flex-row items-center justify-between space-y-0">
 					<CardTitle>Server Health</CardTitle>
 					{canModify && (
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={() => setCleanupDialogOpen(true)}
-							disabled={cleanupSubmitting}
-						>
-							Clean unused
-						</Button>
+						<div className="flex gap-2">
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={() => setCleanupDialogOpen(true)}
+								disabled={cleanupSubmitting || purgeSubmitting}
+							>
+								Clean unused
+							</Button>
+							{showPurgeButton && (
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => setPurgeDialogOpen(true)}
+									disabled={cleanupSubmitting || purgeSubmitting}
+								>
+									Purge build caches
+								</Button>
+							)}
+						</div>
 					)}
 				</CardHeader>
 				<CardContent>
@@ -125,6 +150,20 @@ export function ServerHealthCard({
 				<p className="text-sm text-gray-600">
 					This runs <code className="font-mono">dokku cleanup</code> to remove unused containers and
 					images. Volumes are not removed.
+				</p>
+			</ConfirmDialog>
+
+			<ConfirmDialog
+				visible={purgeDialogOpen}
+				title="Purge build caches"
+				onClose={() => setPurgeDialogOpen(false)}
+				onConfirm={handlePurgeConfirm}
+				submitting={purgeSubmitting}
+			>
+				<p className="text-sm text-gray-600">
+					This runs <code className="font-mono">dokku repo:purge-cache</code> across all apps to
+					remove build caches. Volumes are not removed and{" "}
+					<code className="font-mono">repo:gc</code> is not run.
 				</p>
 			</ConfirmDialog>
 		</>

--- a/client/src/components/ServerHealthCard.tsx
+++ b/client/src/components/ServerHealthCard.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ConfirmDialog.js";
-import type { ServerHealth } from "../lib/schemas.js";
+import { isDiskUnderPressure, type ServerHealth } from "../lib/schemas.js";
+
+export type MaintenanceActionId = "cleanup" | "purge";
 
 type HealthStatus = ServerHealth["status"];
 type MetricKey = keyof ServerHealth["resources"];
@@ -34,6 +36,40 @@ const HEALTH_STATUS_PRESENTATION: Record<
 	},
 };
 
+const MAINTENANCE_ACTIONS: ReadonlyArray<{
+	id: MaintenanceActionId;
+	label: string;
+	title: string;
+	description: React.ReactNode;
+	visible: (health: ServerHealth) => boolean;
+}> = [
+	{
+		id: "cleanup",
+		label: "Clean unused",
+		title: "Clean unused Dokku resources",
+		description: (
+			<p className="text-sm text-gray-600">
+				This runs <code className="font-mono">dokku cleanup</code> to remove unused containers and
+				images. Volumes are not removed.
+			</p>
+		),
+		visible: () => true,
+	},
+	{
+		id: "purge",
+		label: "Purge build caches",
+		title: "Purge build caches",
+		description: (
+			<p className="text-sm text-gray-600">
+				This runs <code className="font-mono">dokku repo:purge-cache</code> across all apps to
+				remove build caches. Volumes are not removed and <code className="font-mono">repo:gc</code>{" "}
+				is not run.
+			</p>
+		),
+		visible: (health) => isDiskUnderPressure(health.resources.disk.status),
+	},
+];
+
 interface HealthMetricBarProps {
 	label: string;
 	value: number;
@@ -62,35 +98,27 @@ function HealthMetricBar({ label, value, status }: HealthMetricBarProps) {
 interface ServerHealthCardProps {
 	health: ServerHealth;
 	canModify: boolean;
-	cleanupSubmitting: boolean;
-	purgeSubmitting: boolean;
-	onCleanupConfirm: () => void;
-	onPurgeConfirm: () => void;
+	submittingAction: MaintenanceActionId | null;
+	onActionConfirm: (actionId: MaintenanceActionId) => void;
 }
 
 export function ServerHealthCard({
 	health,
 	canModify,
-	cleanupSubmitting,
-	purgeSubmitting,
-	onCleanupConfirm,
-	onPurgeConfirm,
+	submittingAction,
+	onActionConfirm,
 }: ServerHealthCardProps) {
-	const [cleanupDialogOpen, setCleanupDialogOpen] = useState(false);
-	const [purgeDialogOpen, setPurgeDialogOpen] = useState(false);
+	const [activeActionId, setActiveActionId] = useState<MaintenanceActionId | null>(null);
 	const statusPresentation = HEALTH_STATUS_PRESENTATION[health.status];
-	const showPurgeButton =
-		canModify &&
-		(health.resources.disk.status === "warning" || health.resources.disk.status === "critical");
+	const visibleActions = MAINTENANCE_ACTIONS.filter((action) => action.visible(health));
+	const activeAction = MAINTENANCE_ACTIONS.find((action) => action.id === activeActionId);
 
-	const handleCleanupConfirm = () => {
-		onCleanupConfirm();
-		setCleanupDialogOpen(false);
-	};
-
-	const handlePurgeConfirm = () => {
-		onPurgeConfirm();
-		setPurgeDialogOpen(false);
+	const handleConfirm = () => {
+		if (!activeActionId) {
+			return;
+		}
+		onActionConfirm(activeActionId);
+		setActiveActionId(null);
 	};
 
 	return (
@@ -100,24 +128,17 @@ export function ServerHealthCard({
 					<CardTitle>Server Health</CardTitle>
 					{canModify && (
 						<div className="flex gap-2">
-							<Button
-								size="sm"
-								variant="outline"
-								onClick={() => setCleanupDialogOpen(true)}
-								disabled={cleanupSubmitting || purgeSubmitting}
-							>
-								Clean unused
-							</Button>
-							{showPurgeButton && (
+							{visibleActions.map((action) => (
 								<Button
+									key={action.id}
 									size="sm"
 									variant="outline"
-									onClick={() => setPurgeDialogOpen(true)}
-									disabled={cleanupSubmitting || purgeSubmitting}
+									onClick={() => setActiveActionId(action.id)}
+									disabled={submittingAction !== null}
 								>
-									Purge build caches
+									{action.label}
 								</Button>
-							)}
+							))}
 						</div>
 					)}
 				</CardHeader>
@@ -140,32 +161,17 @@ export function ServerHealthCard({
 				</CardContent>
 			</Card>
 
-			<ConfirmDialog
-				visible={cleanupDialogOpen}
-				title="Clean unused Dokku resources"
-				onClose={() => setCleanupDialogOpen(false)}
-				onConfirm={handleCleanupConfirm}
-				submitting={cleanupSubmitting}
-			>
-				<p className="text-sm text-gray-600">
-					This runs <code className="font-mono">dokku cleanup</code> to remove unused containers and
-					images. Volumes are not removed.
-				</p>
-			</ConfirmDialog>
-
-			<ConfirmDialog
-				visible={purgeDialogOpen}
-				title="Purge build caches"
-				onClose={() => setPurgeDialogOpen(false)}
-				onConfirm={handlePurgeConfirm}
-				submitting={purgeSubmitting}
-			>
-				<p className="text-sm text-gray-600">
-					This runs <code className="font-mono">dokku repo:purge-cache</code> across all apps to
-					remove build caches. Volumes are not removed and{" "}
-					<code className="font-mono">repo:gc</code> is not run.
-				</p>
-			</ConfirmDialog>
+			{activeAction && (
+				<ConfirmDialog
+					visible={activeActionId !== null}
+					title={activeAction.title}
+					onClose={() => setActiveActionId(null)}
+					onConfirm={handleConfirm}
+					submitting={submittingAction === activeAction.id}
+				>
+					{activeAction.description}
+				</ConfirmDialog>
+			)}
 		</>
 	);
 }

--- a/client/src/hooks/use-server-maintenance-mutation.ts
+++ b/client/src/hooks/use-server-maintenance-mutation.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { z } from "zod";
+import { useToast } from "@/components/ToastProvider.js";
+import { apiFetch } from "@/lib/api.js";
+import { queryKeys } from "@/lib/query-keys.js";
+import type { CommandResult } from "@/lib/schemas.js";
+
+interface UseServerMaintenanceMutationOptions<T extends CommandResult> {
+	endpoint: string;
+	schema: z.ZodType<T>;
+	successMessage: string;
+	errorMessage: string;
+}
+
+export function useServerMaintenanceMutation<T extends CommandResult>({
+	endpoint,
+	schema,
+	successMessage,
+	errorMessage,
+}: UseServerMaintenanceMutationOptions<T>) {
+	const { addToast } = useToast();
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiFetch(endpoint, schema, { method: "POST" }),
+		onSuccess: () => {
+			addToast("success", successMessage);
+			void queryClient.invalidateQueries({ queryKey: queryKeys.health });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.commands });
+		},
+		onError: (error: Error) => {
+			addToast("error", error.message || errorMessage);
+		},
+	});
+}

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -39,6 +39,11 @@ const ApiErrorSchema = z.object({
 export type ApiError = z.infer<typeof ApiErrorSchema>;
 
 const HealthStatusSchema = z.enum(["ok", "warning", "critical"]);
+export type HealthStatus = z.infer<typeof HealthStatusSchema>;
+
+export function isDiskUnderPressure(status: HealthStatus): boolean {
+	return status === "warning" || status === "critical";
+}
 
 const ResourceHealthSchema = z.object({
 	value: z.number(),

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -18,6 +18,16 @@ export const CommandResultSchema = z.object({
 
 export type CommandResult = z.infer<typeof CommandResultSchema>;
 
+export const PurgeCacheResultSchema = CommandResultSchema.extend({
+	results: z.array(
+		CommandResultSchema.extend({
+			app: z.string(),
+		})
+	),
+});
+
+export type PurgeCacheResult = z.infer<typeof PurgeCacheResultSchema>;
+
 // API Error schema
 const ApiErrorSchema = z.object({
 	error: z.string(),

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -441,6 +441,160 @@ describe("Dashboard", () => {
 		expect(screen.queryByRole("button", { name: "Clean unused" })).not.toBeInTheDocument();
 	});
 
+	it("should show purge button for admin when disk is warning or critical", async () => {
+		apiFetchMock.mockImplementation((endpoint: string) => {
+			if (endpoint === "/server/health") return Promise.resolve(mockHealth);
+			if (endpoint === "/apps") return Promise.resolve(mockApps);
+			if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
+			return Promise.reject(new Error("Unknown endpoint"));
+		});
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
+		});
+	});
+
+	it("should hide purge button for viewer role", async () => {
+		mockAuthState.role = "viewer";
+		mockAuthState.canModify = false;
+
+		apiFetchMock.mockImplementation((endpoint: string) => {
+			if (endpoint === "/server/health") return Promise.resolve(mockCriticalHealth);
+			if (endpoint === "/apps") return Promise.resolve(mockApps);
+			if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
+			return Promise.reject(new Error("Unknown endpoint"));
+		});
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("VPS status: Warning")).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole("button", { name: "Purge build caches" })).not.toBeInTheDocument();
+	});
+
+	it("should hide purge button when disk is ok", async () => {
+		apiFetchMock.mockImplementation((endpoint: string) => {
+			if (endpoint === "/server/health") return Promise.resolve(mockOkHealth);
+			if (endpoint === "/apps") return Promise.resolve(mockApps);
+			if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
+			return Promise.reject(new Error("Unknown endpoint"));
+		});
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Clean unused" })).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole("button", { name: "Purge build caches" })).not.toBeInTheDocument();
+	});
+
+	it("should confirm purge cache, call endpoint, and refresh data", async () => {
+		const user = userEvent.setup();
+		let healthFetchCount = 0;
+		let commandsFetchCount = 0;
+
+		apiFetchMock.mockImplementation(
+			(endpoint: string, _schema?: unknown, options?: RequestInit) => {
+				if (endpoint === "/server/purge-cache" && options?.method === "POST") {
+					return Promise.resolve({
+						command: "dokku repo:purge-cache --all-apps",
+						exitCode: 0,
+						stdout: "Purged caches",
+						stderr: "",
+						results: [],
+					});
+				}
+				if (endpoint === "/server/health") {
+					healthFetchCount++;
+					return Promise.resolve(mockHealth);
+				}
+				if (endpoint === "/apps") return Promise.resolve(mockApps);
+				if (endpoint === "/commands?limit=20") {
+					commandsFetchCount++;
+					return Promise.resolve(mockCommands);
+				}
+				return Promise.reject(new Error("Unknown endpoint"));
+			}
+		);
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
+		});
+
+		const initialHealthFetches = healthFetchCount;
+		const initialCommandsFetches = commandsFetchCount;
+
+		await user.click(screen.getByRole("button", { name: "Purge build caches" }));
+		await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+		await waitFor(() => {
+			expect(apiFetchMock).toHaveBeenCalledWith(
+				"/server/purge-cache",
+				expect.anything(),
+				expect.objectContaining({ method: "POST" })
+			);
+			expect(mockToastContext.addToast).toHaveBeenCalledWith("success", "Build caches purged");
+			expect(healthFetchCount).toBeGreaterThan(initialHealthFetches);
+			expect(commandsFetchCount).toBeGreaterThan(initialCommandsFetches);
+		});
+	});
+
+	it("should show error toast when purge cache fails", async () => {
+		const user = userEvent.setup();
+
+		apiFetchMock.mockImplementation(
+			(endpoint: string, _schema?: unknown, options?: RequestInit) => {
+				if (endpoint === "/server/purge-cache" && options?.method === "POST") {
+					return Promise.reject(new Error("purge failed"));
+				}
+				if (endpoint === "/server/health") return Promise.resolve(mockHealth);
+				if (endpoint === "/apps") return Promise.resolve(mockApps);
+				if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
+				return Promise.reject(new Error("Unknown endpoint"));
+			}
+		);
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
+		});
+
+		await user.click(screen.getByRole("button", { name: "Purge build caches" }));
+		await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+		await waitFor(() => {
+			expect(mockToastContext.addToast).toHaveBeenCalledWith("error", "purge failed");
+		});
+	});
+
 	it("should confirm cleanup, call endpoint, and refresh data", async () => {
 		const user = userEvent.setup();
 		let healthFetchCount = 0;

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -94,6 +94,34 @@ const mockApps: App[] = [
 	},
 ];
 
+type DashboardMockOptions = {
+	health?: ServerHealth;
+	apps?: App[];
+	commands?: CommandHistory[];
+	maintenance?: Record<string, { response?: unknown; error?: Error }>;
+};
+
+function createDashboardMock({
+	health = mockHealth,
+	apps = mockApps,
+	commands = mockCommands,
+	maintenance = {},
+}: DashboardMockOptions = {}) {
+	return (endpoint: string, _schema?: unknown, options?: RequestInit) => {
+		const maintenanceConfig = maintenance[endpoint];
+		if (maintenanceConfig && options?.method === "POST") {
+			if (maintenanceConfig.error) {
+				return Promise.reject(maintenanceConfig.error);
+			}
+			return Promise.resolve(maintenanceConfig.response);
+		}
+		if (endpoint === "/server/health") return Promise.resolve(health);
+		if (endpoint === "/apps") return Promise.resolve(apps);
+		if (endpoint === "/commands?limit=20") return Promise.resolve(commands);
+		return Promise.reject(new Error("Unknown endpoint"));
+	};
+}
+
 const mockCommands: CommandHistory[] = [
 	{
 		id: 1,
@@ -115,6 +143,20 @@ const mockCommands: CommandHistory[] = [
 
 describe("Dashboard", () => {
 	let apiFetchMock: ReturnType<typeof vi.fn>;
+
+	async function renderLoadedDashboard(options: DashboardMockOptions = {}) {
+		apiFetchMock.mockImplementation(createDashboardMock(options));
+
+		renderWithQueryClient(
+			<MemoryRouter>
+				<Dashboard />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("Server Health")).toBeInTheDocument();
+		});
+	}
 
 	beforeEach(async () => {
 		vi.clearAllMocks();
@@ -399,22 +441,9 @@ describe("Dashboard", () => {
 	});
 
 	it("should show cleanup button for admin", async () => {
-		apiFetchMock.mockImplementation((endpoint: string) => {
-			if (endpoint === "/server/health") return Promise.resolve(mockHealth);
-			if (endpoint === "/apps") return Promise.resolve(mockApps);
-			if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
-			return Promise.reject(new Error("Unknown endpoint"));
-		});
+		await renderLoadedDashboard();
 
-		renderWithQueryClient(
-			<MemoryRouter>
-				<Dashboard />
-			</MemoryRouter>
-		);
-
-		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "Clean unused" })).toBeInTheDocument();
-		});
+		expect(screen.getByRole("button", { name: "Clean unused" })).toBeInTheDocument();
 	});
 
 	it("should hide cleanup button for viewer role", async () => {
@@ -442,22 +471,9 @@ describe("Dashboard", () => {
 	});
 
 	it("should show purge button for admin when disk is warning or critical", async () => {
-		apiFetchMock.mockImplementation((endpoint: string) => {
-			if (endpoint === "/server/health") return Promise.resolve(mockHealth);
-			if (endpoint === "/apps") return Promise.resolve(mockApps);
-			if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
-			return Promise.reject(new Error("Unknown endpoint"));
-		});
+		await renderLoadedDashboard();
 
-		renderWithQueryClient(
-			<MemoryRouter>
-				<Dashboard />
-			</MemoryRouter>
-		);
-
-		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
-		});
+		expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
 	});
 
 	it("should hide purge button for viewer role", async () => {
@@ -505,28 +521,51 @@ describe("Dashboard", () => {
 		expect(screen.queryByRole("button", { name: "Purge build caches" })).not.toBeInTheDocument();
 	});
 
-	it("should confirm purge cache, call endpoint, and refresh data", async () => {
+	it.each([
+		{
+			buttonLabel: "Purge build caches",
+			endpoint: "/server/purge-cache",
+			successToast: "Build caches purged",
+			response: {
+				command: "dokku repo:purge-cache --all-apps",
+				exitCode: 0,
+				stdout: "Purged caches",
+				stderr: "",
+				results: [],
+			},
+		},
+		{
+			buttonLabel: "Clean unused",
+			endpoint: "/server/cleanup",
+			successToast: "Cleanup completed",
+			response: {
+				command: "dokku cleanup",
+				exitCode: 0,
+				stdout: "Cleanup complete",
+				stderr: "",
+			},
+		},
+	])("should confirm $buttonLabel, call endpoint, and refresh data", async ({
+		buttonLabel,
+		endpoint,
+		successToast,
+		response,
+	}) => {
 		const user = userEvent.setup();
 		let healthFetchCount = 0;
 		let commandsFetchCount = 0;
 
 		apiFetchMock.mockImplementation(
-			(endpoint: string, _schema?: unknown, options?: RequestInit) => {
-				if (endpoint === "/server/purge-cache" && options?.method === "POST") {
-					return Promise.resolve({
-						command: "dokku repo:purge-cache --all-apps",
-						exitCode: 0,
-						stdout: "Purged caches",
-						stderr: "",
-						results: [],
-					});
+			(fetchEndpoint: string, _schema?: unknown, options?: RequestInit) => {
+				if (fetchEndpoint === endpoint && options?.method === "POST") {
+					return Promise.resolve(response);
 				}
-				if (endpoint === "/server/health") {
+				if (fetchEndpoint === "/server/health") {
 					healthFetchCount++;
 					return Promise.resolve(mockHealth);
 				}
-				if (endpoint === "/apps") return Promise.resolve(mockApps);
-				if (endpoint === "/commands?limit=20") {
+				if (fetchEndpoint === "/apps") return Promise.resolve(mockApps);
+				if (fetchEndpoint === "/commands?limit=20") {
 					commandsFetchCount++;
 					return Promise.resolve(mockCommands);
 				}
@@ -541,22 +580,22 @@ describe("Dashboard", () => {
 		);
 
 		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: buttonLabel })).toBeInTheDocument();
 		});
 
 		const initialHealthFetches = healthFetchCount;
 		const initialCommandsFetches = commandsFetchCount;
 
-		await user.click(screen.getByRole("button", { name: "Purge build caches" }));
+		await user.click(screen.getByRole("button", { name: buttonLabel }));
 		await user.click(screen.getByRole("button", { name: "Confirm" }));
 
 		await waitFor(() => {
 			expect(apiFetchMock).toHaveBeenCalledWith(
-				"/server/purge-cache",
+				endpoint,
 				expect.anything(),
 				expect.objectContaining({ method: "POST" })
 			);
-			expect(mockToastContext.addToast).toHaveBeenCalledWith("success", "Build caches purged");
+			expect(mockToastContext.addToast).toHaveBeenCalledWith("success", successToast);
 			expect(healthFetchCount).toBeGreaterThan(initialHealthFetches);
 			expect(commandsFetchCount).toBeGreaterThan(initialCommandsFetches);
 		});
@@ -565,26 +604,10 @@ describe("Dashboard", () => {
 	it("should show error toast when purge cache fails", async () => {
 		const user = userEvent.setup();
 
-		apiFetchMock.mockImplementation(
-			(endpoint: string, _schema?: unknown, options?: RequestInit) => {
-				if (endpoint === "/server/purge-cache" && options?.method === "POST") {
-					return Promise.reject(new Error("purge failed"));
-				}
-				if (endpoint === "/server/health") return Promise.resolve(mockHealth);
-				if (endpoint === "/apps") return Promise.resolve(mockApps);
-				if (endpoint === "/commands?limit=20") return Promise.resolve(mockCommands);
-				return Promise.reject(new Error("Unknown endpoint"));
-			}
-		);
-
-		renderWithQueryClient(
-			<MemoryRouter>
-				<Dashboard />
-			</MemoryRouter>
-		);
-
-		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "Purge build caches" })).toBeInTheDocument();
+		await renderLoadedDashboard({
+			maintenance: {
+				"/server/purge-cache": { error: new Error("purge failed") },
+			},
 		});
 
 		await user.click(screen.getByRole("button", { name: "Purge build caches" }));
@@ -592,62 +615,6 @@ describe("Dashboard", () => {
 
 		await waitFor(() => {
 			expect(mockToastContext.addToast).toHaveBeenCalledWith("error", "purge failed");
-		});
-	});
-
-	it("should confirm cleanup, call endpoint, and refresh data", async () => {
-		const user = userEvent.setup();
-		let healthFetchCount = 0;
-		let commandsFetchCount = 0;
-
-		apiFetchMock.mockImplementation(
-			(endpoint: string, _schema?: unknown, options?: RequestInit) => {
-				if (endpoint === "/server/cleanup" && options?.method === "POST") {
-					return Promise.resolve({
-						command: "dokku cleanup",
-						exitCode: 0,
-						stdout: "Cleanup complete",
-						stderr: "",
-					});
-				}
-				if (endpoint === "/server/health") {
-					healthFetchCount++;
-					return Promise.resolve(mockOkHealth);
-				}
-				if (endpoint === "/apps") return Promise.resolve(mockApps);
-				if (endpoint === "/commands?limit=20") {
-					commandsFetchCount++;
-					return Promise.resolve(mockCommands);
-				}
-				return Promise.reject(new Error("Unknown endpoint"));
-			}
-		);
-
-		renderWithQueryClient(
-			<MemoryRouter>
-				<Dashboard />
-			</MemoryRouter>
-		);
-
-		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "Clean unused" })).toBeInTheDocument();
-		});
-
-		const initialHealthFetches = healthFetchCount;
-		const initialCommandsFetches = commandsFetchCount;
-
-		await user.click(screen.getByRole("button", { name: "Clean unused" }));
-		await user.click(screen.getByRole("button", { name: "Confirm" }));
-
-		await waitFor(() => {
-			expect(apiFetchMock).toHaveBeenCalledWith(
-				"/server/cleanup",
-				expect.anything(),
-				expect.objectContaining({ method: "POST" })
-			);
-			expect(mockToastContext.addToast).toHaveBeenCalledWith("success", "Cleanup completed");
-			expect(healthFetchCount).toBeGreaterThan(initialHealthFetches);
-			expect(commandsFetchCount).toBeGreaterThan(initialCommandsFetches);
 		});
 	});
 });

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { z } from "zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { CreateAppDialog } from "@/components/CreateAppDialog.js";
 import { ServerHealthCard } from "@/components/ServerHealthCard.js";
-import { useToast } from "@/components/ToastProvider.js";
+import { useServerMaintenanceMutation } from "@/hooks/use-server-maintenance-mutation.js";
 import { apiFetch } from "../lib/api.js";
 import { useAuth } from "@/contexts/auth-context.js";
 import { formatDeployTime } from "@/lib/utils.js";
@@ -20,7 +20,6 @@ import {
 
 export function Dashboard() {
 	const { canModify } = useAuth();
-	const { addToast } = useToast();
 	const queryClient = useQueryClient();
 	const [createAppOpen, setCreateAppOpen] = useState(false);
 
@@ -42,29 +41,25 @@ export function Dashboard() {
 		refetchInterval: 30000,
 	});
 
-	const cleanupMutation = useMutation({
-		mutationFn: () => apiFetch("/server/cleanup", CommandResultSchema, { method: "POST" }),
-		onSuccess: () => {
-			addToast("success", "Cleanup completed");
-			void queryClient.invalidateQueries({ queryKey: queryKeys.health });
-			void queryClient.invalidateQueries({ queryKey: queryKeys.commands });
-		},
-		onError: (error: Error) => {
-			addToast("error", error.message || "Cleanup failed");
-		},
+	const cleanupMutation = useServerMaintenanceMutation({
+		endpoint: "/server/cleanup",
+		schema: CommandResultSchema,
+		successMessage: "Cleanup completed",
+		errorMessage: "Cleanup failed",
 	});
 
-	const purgeCacheMutation = useMutation({
-		mutationFn: () => apiFetch("/server/purge-cache", PurgeCacheResultSchema, { method: "POST" }),
-		onSuccess: () => {
-			addToast("success", "Build caches purged");
-			void queryClient.invalidateQueries({ queryKey: queryKeys.health });
-			void queryClient.invalidateQueries({ queryKey: queryKeys.commands });
-		},
-		onError: (error: Error) => {
-			addToast("error", error.message || "Build cache purge failed");
-		},
+	const purgeCacheMutation = useServerMaintenanceMutation({
+		endpoint: "/server/purge-cache",
+		schema: PurgeCacheResultSchema,
+		successMessage: "Build caches purged",
+		errorMessage: "Build cache purge failed",
 	});
+
+	const submittingAction = cleanupMutation.isPending
+		? "cleanup"
+		: purgeCacheMutation.isPending
+			? "purge"
+			: null;
 
 	const isLoading = healthLoading || appsLoading || commandsLoading;
 
@@ -104,10 +99,14 @@ export function Dashboard() {
 						<ServerHealthCard
 							health={health}
 							canModify={canModify}
-							cleanupSubmitting={cleanupMutation.isPending}
-							purgeSubmitting={purgeCacheMutation.isPending}
-							onCleanupConfirm={() => cleanupMutation.mutate()}
-							onPurgeConfirm={() => purgeCacheMutation.mutate()}
+							submittingAction={submittingAction}
+							onActionConfirm={(actionId) => {
+								if (actionId === "cleanup") {
+									cleanupMutation.mutate();
+									return;
+								}
+								purgeCacheMutation.mutate();
+							}}
 						/>
 					)}
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 	AppSchema,
 	CommandHistorySchema,
 	CommandResultSchema,
+	PurgeCacheResultSchema,
 } from "../lib/schemas.js";
 
 export function Dashboard() {
@@ -50,6 +51,18 @@ export function Dashboard() {
 		},
 		onError: (error: Error) => {
 			addToast("error", error.message || "Cleanup failed");
+		},
+	});
+
+	const purgeCacheMutation = useMutation({
+		mutationFn: () => apiFetch("/server/purge-cache", PurgeCacheResultSchema, { method: "POST" }),
+		onSuccess: () => {
+			addToast("success", "Build caches purged");
+			void queryClient.invalidateQueries({ queryKey: queryKeys.health });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.commands });
+		},
+		onError: (error: Error) => {
+			addToast("error", error.message || "Build cache purge failed");
 		},
 	});
 
@@ -92,7 +105,9 @@ export function Dashboard() {
 							health={health}
 							canModify={canModify}
 							cleanupSubmitting={cleanupMutation.isPending}
+							purgeSubmitting={purgeCacheMutation.isPending}
 							onCleanupConfirm={() => cleanupMutation.mutate()}
+							onPurgeConfirm={() => purgeCacheMutation.mutate()}
 						/>
 					)}
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -211,9 +211,11 @@ The dashboard **Server Health** card shows live VPS resource usage for CPU, memo
 
 The overall VPS status reflects the worst metric — if disk is at 95% but CPU is low, the banner shows critical.
 
-**Clean unused (operators and admins only):** click **Clean unused** on the Server Health card to run `dokku cleanup`. This removes dead containers and dangling images. It does **not** purge build caches (`repo:purge-cache`), run `repo:gc`, or execute `docker system prune`. Viewers can see health metrics but cannot trigger cleanup.
+**Clean unused (operators and admins only):** click **Clean unused** on the Server Health card to run `dokku cleanup`. This removes dead containers and dangling images. It does **not** purge build caches, run `repo:gc`, or execute `docker system prune`.
 
-If deploys fail with `no space left on device`, see [Disk full during deploy](#disk-full-during-deploy) for SSH-based recovery steps beyond what the dashboard button covers.
+**Purge build caches (operators and admins only):** when disk status is **Watch closely** or **Warning** (70%+), a second button appears to run `dokku repo:purge-cache` across all apps. Use this as a second tier after **Clean unused** if disk pressure remains. It does **not** remove volumes or run `repo:gc`. Viewers can see health metrics but cannot trigger either action.
+
+If deploys fail with `no space left on device`, see [Disk full during deploy](#disk-full-during-deploy) for SSH-based recovery steps beyond what the dashboard buttons cover.
 
 ## Persistent Storage (Important)
 
@@ -596,7 +598,12 @@ git push dokku <your-branch>:main
 
 A non-fast-forward rejection after cleanup is normal when the remote is ahead of your local branch — push the branch you intend to deploy, not necessarily local `main`.
 
-**From Docklight (operators/admins):** the dashboard **Clean unused** button runs `dokku cleanup` only. It does not purge build caches (`repo:purge-cache`), run `repo:gc`, or execute `docker system prune`. Those still require SSH.
+**From Docklight (operators/admins):** use the dashboard in two tiers when disk is full:
+
+1. **Clean unused** — runs `dokku cleanup` (dead containers and dangling images).
+2. **Purge build caches** — appears when disk is at warning or critical; runs `dokku repo:purge-cache` across all apps.
+
+Neither button runs `repo:gc` or `docker system prune`. Run `repo:gc` manually over SSH if caches alone are not enough.
 
 **Prevention on multi-app servers:** schedule weekly `dokku cleanup` and monthly `repo:purge-cache` + `repo:gc` across apps. Monitor disk via the Docklight dashboard health panel (warning at 70%, critical at 90%).
 

--- a/server/lib/apps.test.ts
+++ b/server/lib/apps.test.ts
@@ -4,6 +4,8 @@ import {
 	getApps,
 	getAppDetail,
 	isValidAppName,
+	listAppNames,
+	parseAppNamesFromListOutput,
 	restartApp,
 	rebuildApp,
 	scaleApp,
@@ -30,6 +32,86 @@ describe("isValidAppName", () => {
 
 		invalidNames.forEach((name) => {
 			expect(isValidAppName(name)).toBe(false);
+		});
+	});
+});
+
+describe("parseAppNamesFromListOutput", () => {
+	it("should parse and filter valid app names", () => {
+		expect(parseAppNamesFromListOutput("my-app\nanother-app\nINVALID\n")).toEqual([
+			"my-app",
+			"another-app",
+		]);
+	});
+});
+
+describe("listAppNames", () => {
+	const mockExecuteCommand = executeCommand as ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should return app names from quiet list", async () => {
+		mockExecuteCommand.mockResolvedValue({
+			command: "dokku --quiet apps:list",
+			exitCode: 0,
+			stdout: "my-app\nanother-app",
+			stderr: "",
+		});
+
+		const result = await listAppNames();
+
+		expect(result).toEqual({ ok: true, names: ["my-app", "another-app"] });
+		expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it("should fall back to apps:list when quiet list fails", async () => {
+		mockExecuteCommand
+			.mockResolvedValueOnce({
+				command: "dokku --quiet apps:list",
+				exitCode: 1,
+				stdout: "",
+				stderr: "quiet failed",
+			})
+			.mockResolvedValueOnce({
+				command: "dokku apps:list",
+				exitCode: 0,
+				stdout: "my-app",
+				stderr: "",
+			});
+
+		const result = await listAppNames();
+
+		expect(result).toEqual({ ok: true, names: ["my-app"] });
+		expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
+	});
+
+	it("should return an error when both list commands fail", async () => {
+		mockExecuteCommand
+			.mockResolvedValueOnce({
+				command: "dokku --quiet apps:list",
+				exitCode: 1,
+				stdout: "",
+				stderr: "quiet failed",
+			})
+			.mockResolvedValueOnce({
+				command: "dokku apps:list",
+				exitCode: 1,
+				stdout: "",
+				stderr: "apps list failed",
+			});
+
+		const result = await listAppNames();
+
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				command: "dokku apps:list",
+				exitCode: 1,
+				stdout: "",
+				stderr: "apps list failed",
+			},
 		});
 	});
 });

--- a/server/lib/apps.ts
+++ b/server/lib/apps.ts
@@ -40,49 +40,75 @@ function createValidationError(commandName: string): typeof INVALID_NAME_ERROR {
 	return { ...INVALID_NAME_ERROR, command: `${commandName}-validation` };
 }
 
-export async function getApps(
-	userId?: string
-): Promise<App[] | { error: string; command: string; exitCode: number; stderr: string }> {
+export type AppNamesListResult =
+	| { ok: true; names: string[] }
+	| { ok: false; error: CommandResult; unexpected?: boolean };
+
+export function parseAppNamesFromListOutput(stdout: string): string[] {
+	return stdout
+		.split("\n")
+		.map((line) => stripAnsi(line).trim())
+		.filter(isValidAppName);
+}
+
+export async function listAppNames(userId?: string): Promise<AppNamesListResult> {
 	const fallbackCommand = DokkuCommands.appsList();
+	const listCommands = [DokkuCommands.appsListQuiet(), DokkuCommands.appsList()];
+	let listResult: CommandResult | undefined;
 
 	try {
-		const listCommands = [DokkuCommands.appsListQuiet(), DokkuCommands.appsList()];
-		let listResult: CommandResult | undefined;
-
 		for (const command of listCommands) {
 			const result = await executeCommand(command, 30000, { userId });
 			if (result.exitCode === 0) {
-				return await fetchAppDetails(result.stdout, userId);
+				return { ok: true, names: parseAppNamesFromListOutput(result.stdout) };
 			}
 			listResult = result;
 		}
 
 		return {
-			error: "Failed to list apps",
-			command: listResult?.command || fallbackCommand,
-			exitCode: listResult?.exitCode || 1,
-			stderr: withRuntimeHint(
-				listResult?.command || fallbackCommand,
-				listResult?.stderr || UNKNOWN_ERROR
-			),
+			ok: false,
+			error: {
+				command: listResult?.command || fallbackCommand,
+				exitCode: listResult?.exitCode || 1,
+				stdout: "",
+				stderr: withRuntimeHint(
+					listResult?.command || fallbackCommand,
+					listResult?.stderr || UNKNOWN_ERROR
+				),
+			},
 		};
 	} catch (error: unknown) {
 		const err = error as { message?: string };
 		return {
-			error: err.message || UNKNOWN_ERROR,
-			command: fallbackCommand,
-			exitCode: 1,
-			stderr: err.message || "",
+			ok: false,
+			unexpected: true,
+			error: {
+				command: fallbackCommand,
+				exitCode: 1,
+				stdout: "",
+				stderr: err.message || "",
+			},
 		};
 	}
 }
 
-async function fetchAppDetails(stdout: string, userId?: string): Promise<App[]> {
-	const appNames = stdout
-		.split("\n")
-		.map((line) => stripAnsi(line).trim())
-		.filter(isValidAppName);
+export async function getApps(
+	userId?: string
+): Promise<App[] | { error: string; command: string; exitCode: number; stderr: string }> {
+	const listResult = await listAppNames(userId);
+	if (!listResult.ok) {
+		return {
+			error: listResult.unexpected ? listResult.error.stderr : "Failed to list apps",
+			command: listResult.error.command,
+			exitCode: listResult.error.exitCode,
+			stderr: listResult.error.stderr,
+		};
+	}
 
+	return fetchAppDetails(listResult.names, userId);
+}
+
+async function fetchAppDetails(appNames: string[], userId?: string): Promise<App[]> {
 	if (appNames.length === 0) {
 		return [];
 	}

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -310,8 +310,8 @@ describe("DokkuCommands", () => {
 			expect(DokkuCommands.cleanup()).toBe("dokku cleanup");
 		});
 
-		it("repoPurgeCache returns repo:purge-cache command with app name", () => {
-			expect(DokkuCommands.repoPurgeCache("my-app")).toBe("dokku repo:purge-cache my-app");
+		it("repoPurgeCache returns repo:purge-cache command with quoted app name", () => {
+			expect(DokkuCommands.repoPurgeCache("my-app")).toBe("dokku repo:purge-cache 'my-app'");
 		});
 	});
 

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -305,6 +305,16 @@ describe("DokkuCommands", () => {
 		});
 	});
 
+	describe("server maintenance", () => {
+		it("cleanup returns cleanup command", () => {
+			expect(DokkuCommands.cleanup()).toBe("dokku cleanup");
+		});
+
+		it("repoPurgeCache returns repo:purge-cache command with app name", () => {
+			expect(DokkuCommands.repoPurgeCache("my-app")).toBe("dokku repo:purge-cache my-app");
+		});
+	});
+
 	describe("logs", () => {
 		it("logsFollow returns logs command with tail and follow flags", () => {
 			expect(DokkuCommands.logsFollow("my-app", 100)).toBe("dokku logs 'my-app' -t -n 100");

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -16,6 +16,7 @@ export interface DokkuCommands {
 
 	// Server maintenance
 	cleanup(): string;
+	repoPurgeCache(app: string): string;
 
 	// Apps
 	appsList(): string;
@@ -124,6 +125,7 @@ export const DokkuCommands: DokkuCommands = {
 
 	// Server maintenance
 	cleanup: (): string => "dokku cleanup",
+	repoPurgeCache: (app: string): string => `dokku repo:purge-cache ${app}`,
 
 	// Apps
 	appsList: (): string => "dokku apps:list",

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -125,7 +125,7 @@ export const DokkuCommands: DokkuCommands = {
 
 	// Server maintenance
 	cleanup: (): string => "dokku cleanup",
-	repoPurgeCache: (app: string): string => `dokku repo:purge-cache ${app}`,
+	repoPurgeCache: (app: string): string => `dokku repo:purge-cache ${shellQuote(app)}`,
 
 	// Apps
 	appsList: (): string => "dokku apps:list",

--- a/server/lib/server-maintenance.test.ts
+++ b/server/lib/server-maintenance.test.ts
@@ -13,6 +13,7 @@ import { executeCommand } from "./executor.js";
 import {
 	MAINTENANCE_TIMEOUT_MS,
 	PURGE_AGGREGATE_COMMAND,
+	PURGE_CACHE_TIMEOUT_MS,
 	purgeAllAppCaches,
 	runCleanup,
 } from "./server-maintenance.js";
@@ -52,7 +53,7 @@ describe("server-maintenance", () => {
 				names: ["app-one", "app-two"],
 			});
 			vi.mocked(executeCommand).mockImplementation(async (command: string) => {
-				if (command === "dokku repo:purge-cache app-one") {
+				if (command === "dokku repo:purge-cache 'app-one'") {
 					return {
 						command,
 						exitCode: 0,
@@ -78,14 +79,14 @@ describe("server-maintenance", () => {
 				results: [
 					{
 						app: "app-one",
-						command: "dokku repo:purge-cache app-one",
+						command: "dokku repo:purge-cache 'app-one'",
 						exitCode: 0,
 						stdout: "Purged app-one",
 						stderr: "",
 					},
 					{
 						app: "app-two",
-						command: "dokku repo:purge-cache app-two",
+						command: "dokku repo:purge-cache 'app-two'",
 						exitCode: 0,
 						stdout: "Purged app-two",
 						stderr: "",
@@ -93,6 +94,16 @@ describe("server-maintenance", () => {
 				],
 			});
 			expect(executeCommand).toHaveBeenCalledTimes(2);
+			expect(executeCommand).toHaveBeenCalledWith(
+				"dokku repo:purge-cache 'app-one'",
+				PURGE_CACHE_TIMEOUT_MS,
+				{ userId: "1" }
+			);
+			expect(executeCommand).toHaveBeenCalledWith(
+				"dokku repo:purge-cache 'app-two'",
+				PURGE_CACHE_TIMEOUT_MS,
+				{ userId: "1" }
+			);
 		});
 
 		it("should return an error when app listing fails", async () => {
@@ -124,7 +135,7 @@ describe("server-maintenance", () => {
 				names: ["app-one", "app-two"],
 			});
 			vi.mocked(executeCommand).mockImplementation(async (command: string) => {
-				if (command === "dokku repo:purge-cache app-two") {
+				if (command === "dokku repo:purge-cache 'app-two'") {
 					return {
 						command,
 						exitCode: 1,
@@ -150,14 +161,14 @@ describe("server-maintenance", () => {
 				results: [
 					{
 						app: "app-one",
-						command: "dokku repo:purge-cache app-one",
+						command: "dokku repo:purge-cache 'app-one'",
 						exitCode: 0,
 						stdout: "Purged app-one",
 						stderr: "",
 					},
 					{
 						app: "app-two",
-						command: "dokku repo:purge-cache app-two",
+						command: "dokku repo:purge-cache 'app-two'",
 						exitCode: 1,
 						stdout: "",
 						stderr: "purge failed",

--- a/server/lib/server-maintenance.test.ts
+++ b/server/lib/server-maintenance.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./apps.js", () => ({
+	listAppNames: vi.fn(),
+}));
+
+vi.mock("./executor.js", () => ({
+	executeCommand: vi.fn(),
+}));
+
+import { listAppNames } from "./apps.js";
+import { executeCommand } from "./executor.js";
+import {
+	MAINTENANCE_TIMEOUT_MS,
+	PURGE_AGGREGATE_COMMAND,
+	purgeAllAppCaches,
+	runCleanup,
+} from "./server-maintenance.js";
+
+describe("server-maintenance", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	describe("runCleanup", () => {
+		it("should run dokku cleanup", async () => {
+			vi.mocked(executeCommand).mockResolvedValue({
+				command: "dokku cleanup",
+				exitCode: 0,
+				stdout: "Cleanup complete",
+				stderr: "",
+			});
+
+			const result = await runCleanup("1");
+
+			expect(result).toEqual({
+				command: "dokku cleanup",
+				exitCode: 0,
+				stdout: "Cleanup complete",
+				stderr: "",
+			});
+			expect(executeCommand).toHaveBeenCalledWith("dokku cleanup", MAINTENANCE_TIMEOUT_MS, {
+				userId: "1",
+			});
+		});
+	});
+
+	describe("purgeAllAppCaches", () => {
+		it("should purge caches for all listed apps", async () => {
+			vi.mocked(listAppNames).mockResolvedValue({
+				ok: true,
+				names: ["app-one", "app-two"],
+			});
+			vi.mocked(executeCommand).mockImplementation(async (command: string) => {
+				if (command === "dokku repo:purge-cache app-one") {
+					return {
+						command,
+						exitCode: 0,
+						stdout: "Purged app-one",
+						stderr: "",
+					};
+				}
+				return {
+					command,
+					exitCode: 0,
+					stdout: "Purged app-two",
+					stderr: "",
+				};
+			});
+
+			const result = await purgeAllAppCaches("1");
+
+			expect(result).toEqual({
+				command: PURGE_AGGREGATE_COMMAND,
+				exitCode: 0,
+				stdout: "Purged app-one\nPurged app-two",
+				stderr: "",
+				results: [
+					{
+						app: "app-one",
+						command: "dokku repo:purge-cache app-one",
+						exitCode: 0,
+						stdout: "Purged app-one",
+						stderr: "",
+					},
+					{
+						app: "app-two",
+						command: "dokku repo:purge-cache app-two",
+						exitCode: 0,
+						stdout: "Purged app-two",
+						stderr: "",
+					},
+				],
+			});
+			expect(executeCommand).toHaveBeenCalledTimes(2);
+		});
+
+		it("should return an error when app listing fails", async () => {
+			vi.mocked(listAppNames).mockResolvedValue({
+				ok: false,
+				error: {
+					command: "dokku apps:list",
+					exitCode: 1,
+					stdout: "",
+					stderr: "apps list failed",
+				},
+			});
+
+			const result = await purgeAllAppCaches("1");
+
+			expect(result).toEqual({
+				command: PURGE_AGGREGATE_COMMAND,
+				exitCode: 1,
+				stdout: "",
+				stderr: "apps list failed",
+				results: [],
+			});
+			expect(executeCommand).not.toHaveBeenCalled();
+		});
+
+		it("should return aggregate failure when one app purge fails", async () => {
+			vi.mocked(listAppNames).mockResolvedValue({
+				ok: true,
+				names: ["app-one", "app-two"],
+			});
+			vi.mocked(executeCommand).mockImplementation(async (command: string) => {
+				if (command === "dokku repo:purge-cache app-two") {
+					return {
+						command,
+						exitCode: 1,
+						stdout: "",
+						stderr: "purge failed",
+					};
+				}
+				return {
+					command,
+					exitCode: 0,
+					stdout: "Purged app-one",
+					stderr: "",
+				};
+			});
+
+			const result = await purgeAllAppCaches("1");
+
+			expect(result).toEqual({
+				command: PURGE_AGGREGATE_COMMAND,
+				exitCode: 1,
+				stdout: "Purged app-one",
+				stderr: "purge failed",
+				results: [
+					{
+						app: "app-one",
+						command: "dokku repo:purge-cache app-one",
+						exitCode: 0,
+						stdout: "Purged app-one",
+						stderr: "",
+					},
+					{
+						app: "app-two",
+						command: "dokku repo:purge-cache app-two",
+						exitCode: 1,
+						stdout: "",
+						stderr: "purge failed",
+					},
+				],
+			});
+		});
+	});
+});

--- a/server/lib/server-maintenance.ts
+++ b/server/lib/server-maintenance.ts
@@ -3,6 +3,7 @@ import { type CommandResult, executeCommand } from "./executor.js";
 import { DokkuCommands } from "./dokku.js";
 
 export const MAINTENANCE_TIMEOUT_MS = 120000;
+export const PURGE_CACHE_TIMEOUT_MS = 30000;
 export const PURGE_AGGREGATE_COMMAND = "dokku repo:purge-cache --all-apps";
 
 export interface PurgeCacheResult extends CommandResult {
@@ -27,7 +28,7 @@ export async function purgeAllAppCaches(userId?: string): Promise<PurgeCacheResu
 
 	const results: Array<CommandResult & { app: string }> = [];
 	for (const app of listResult.names) {
-		const result = await executeCommand(DokkuCommands.repoPurgeCache(app), MAINTENANCE_TIMEOUT_MS, {
+		const result = await executeCommand(DokkuCommands.repoPurgeCache(app), PURGE_CACHE_TIMEOUT_MS, {
 			userId,
 		});
 		results.push({ ...result, app });

--- a/server/lib/server-maintenance.ts
+++ b/server/lib/server-maintenance.ts
@@ -1,0 +1,50 @@
+import { listAppNames } from "./apps.js";
+import { type CommandResult, executeCommand } from "./executor.js";
+import { DokkuCommands } from "./dokku.js";
+
+export const MAINTENANCE_TIMEOUT_MS = 120000;
+export const PURGE_AGGREGATE_COMMAND = "dokku repo:purge-cache --all-apps";
+
+export interface PurgeCacheResult extends CommandResult {
+	results: Array<CommandResult & { app: string }>;
+}
+
+export async function runCleanup(userId?: string): Promise<CommandResult> {
+	return executeCommand(DokkuCommands.cleanup(), MAINTENANCE_TIMEOUT_MS, { userId });
+}
+
+export async function purgeAllAppCaches(userId?: string): Promise<PurgeCacheResult> {
+	const listResult = await listAppNames(userId);
+	if (!listResult.ok) {
+		return {
+			command: PURGE_AGGREGATE_COMMAND,
+			exitCode: listResult.error.exitCode,
+			stdout: "",
+			stderr: listResult.error.stderr,
+			results: [],
+		};
+	}
+
+	const results: Array<CommandResult & { app: string }> = [];
+	for (const app of listResult.names) {
+		const result = await executeCommand(DokkuCommands.repoPurgeCache(app), MAINTENANCE_TIMEOUT_MS, {
+			userId,
+		});
+		results.push({ ...result, app });
+	}
+
+	const failedResults = results.filter((result) => result.exitCode !== 0);
+	return {
+		command: PURGE_AGGREGATE_COMMAND,
+		exitCode: failedResults.length > 0 ? 1 : 0,
+		stdout: results
+			.map((result) => result.stdout)
+			.filter(Boolean)
+			.join("\n"),
+		stderr: failedResults
+			.map((result) => result.stderr)
+			.filter(Boolean)
+			.join("\n"),
+		results,
+	};
+}

--- a/server/routes/server.test.ts
+++ b/server/routes/server.test.ts
@@ -67,6 +67,7 @@ describe("Server routes", () => {
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		vi.mocked(executeCommand).mockReset();
 		vi.mocked(get).mockReturnValue(undefined);
 		app = createTestApp();
 	});
@@ -148,6 +149,166 @@ describe("Server routes", () => {
 				exitCode: 1,
 				stdout: "",
 				stderr: "cleanup failed",
+			});
+			expect(insertAuditLog).not.toHaveBeenCalled();
+			expect(del).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("POST /api/server/purge-cache", () => {
+		it("should purge all app caches for operators", async () => {
+			vi.mocked(executeCommand)
+				.mockResolvedValueOnce({
+					command: "dokku --quiet apps:list",
+					exitCode: 0,
+					stdout: "app-one\napp-two",
+					stderr: "",
+				})
+				.mockResolvedValueOnce({
+					command: "dokku repo:purge-cache app-one",
+					exitCode: 0,
+					stdout: "Purged app-one",
+					stderr: "",
+				})
+				.mockResolvedValueOnce({
+					command: "dokku repo:purge-cache app-two",
+					exitCode: 0,
+					stdout: "Purged app-two",
+					stderr: "",
+				});
+
+			const response = await request(app)
+				.post("/api/server/purge-cache")
+				.set("x-test-role", "operator");
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({
+				command: "dokku repo:purge-cache --all-apps",
+				exitCode: 0,
+				stdout: "Purged app-one\nPurged app-two",
+				stderr: "",
+				results: [
+					{
+						app: "app-one",
+						command: "dokku repo:purge-cache app-one",
+						exitCode: 0,
+						stdout: "Purged app-one",
+						stderr: "",
+					},
+					{
+						app: "app-two",
+						command: "dokku repo:purge-cache app-two",
+						exitCode: 0,
+						stdout: "Purged app-two",
+						stderr: "",
+					},
+				],
+			});
+			expect(executeCommand).toHaveBeenCalledTimes(3);
+			expect(executeCommand).toHaveBeenNthCalledWith(1, "dokku --quiet apps:list", 30000, {
+				userId: "1",
+			});
+			expect(executeCommand).toHaveBeenNthCalledWith(2, "dokku repo:purge-cache app-one", 120000, {
+				userId: "1",
+			});
+			expect(executeCommand).toHaveBeenNthCalledWith(3, "dokku repo:purge-cache app-two", 120000, {
+				userId: "1",
+			});
+			expect(insertAuditLog).toHaveBeenCalledWith(
+				1,
+				"server:purge-cache",
+				null,
+				null,
+				expect.any(String)
+			);
+			expect(del).toHaveBeenCalledWith("server:health");
+		});
+
+		it("should reject viewers", async () => {
+			const response = await request(app)
+				.post("/api/server/purge-cache")
+				.set("x-test-role", "viewer");
+
+			expect(response.status).toBe(403);
+			expect(response.body).toEqual({ error: "Forbidden" });
+			expect(executeCommand).not.toHaveBeenCalled();
+		});
+
+		it("should return an error when app listing fails without running purge commands", async () => {
+			vi.mocked(executeCommand)
+				.mockResolvedValueOnce({
+					command: "dokku --quiet apps:list",
+					exitCode: 1,
+					stdout: "",
+					stderr: "quiet list failed",
+				})
+				.mockResolvedValueOnce({
+					command: "dokku apps:list",
+					exitCode: 1,
+					stdout: "",
+					stderr: "apps list failed",
+				});
+
+			const response = await request(app).post("/api/server/purge-cache");
+
+			expect(response.status).toBe(500);
+			expect(response.body).toEqual({
+				command: "dokku repo:purge-cache --all-apps",
+				exitCode: 1,
+				stdout: "",
+				stderr: "apps list failed",
+				results: [],
+			});
+			expect(executeCommand).toHaveBeenCalledTimes(2);
+			expect(insertAuditLog).not.toHaveBeenCalled();
+			expect(del).not.toHaveBeenCalled();
+		});
+
+		it("should return aggregate failure when one app purge fails", async () => {
+			vi.mocked(executeCommand)
+				.mockResolvedValueOnce({
+					command: "dokku --quiet apps:list",
+					exitCode: 0,
+					stdout: "app-one\napp-two",
+					stderr: "",
+				})
+				.mockResolvedValueOnce({
+					command: "dokku repo:purge-cache app-one",
+					exitCode: 0,
+					stdout: "Purged app-one",
+					stderr: "",
+				})
+				.mockResolvedValueOnce({
+					command: "dokku repo:purge-cache app-two",
+					exitCode: 1,
+					stdout: "",
+					stderr: "purge failed",
+				});
+
+			const response = await request(app).post("/api/server/purge-cache");
+
+			expect(response.status).toBe(500);
+			expect(response.body).toEqual({
+				command: "dokku repo:purge-cache --all-apps",
+				exitCode: 1,
+				stdout: "Purged app-one",
+				stderr: "purge failed",
+				results: [
+					{
+						app: "app-one",
+						command: "dokku repo:purge-cache app-one",
+						exitCode: 0,
+						stdout: "Purged app-one",
+						stderr: "",
+					},
+					{
+						app: "app-two",
+						command: "dokku repo:purge-cache app-two",
+						exitCode: 1,
+						stdout: "",
+						stderr: "purge failed",
+					},
+				],
 			});
 			expect(insertAuditLog).not.toHaveBeenCalled();
 			expect(del).not.toHaveBeenCalled();

--- a/server/routes/server.test.ts
+++ b/server/routes/server.test.ts
@@ -165,14 +165,14 @@ describe("Server routes", () => {
 				results: [
 					{
 						app: "app-one",
-						command: "dokku repo:purge-cache app-one",
+						command: "dokku repo:purge-cache 'app-one'",
 						exitCode: 0,
 						stdout: "Purged app-one",
 						stderr: "",
 					},
 					{
 						app: "app-two",
-						command: "dokku repo:purge-cache app-two",
+						command: "dokku repo:purge-cache 'app-two'",
 						exitCode: 0,
 						stdout: "Purged app-two",
 						stderr: "",
@@ -231,14 +231,14 @@ describe("Server routes", () => {
 				results: [
 					{
 						app: "app-one",
-						command: "dokku repo:purge-cache app-one",
+						command: "dokku repo:purge-cache 'app-one'",
 						exitCode: 0,
 						stdout: "Purged app-one",
 						stderr: "",
 					},
 					{
 						app: "app-two",
-						command: "dokku repo:purge-cache app-two",
+						command: "dokku repo:purge-cache 'app-two'",
 						exitCode: 1,
 						stdout: "",
 						stderr: "purge failed",

--- a/server/routes/server.test.ts
+++ b/server/routes/server.test.ts
@@ -7,8 +7,9 @@ vi.mock("../lib/server.js", () => ({
 	getServerHealth: vi.fn(),
 }));
 
-vi.mock("../lib/executor.js", () => ({
-	executeCommand: vi.fn(),
+vi.mock("../lib/server-maintenance.js", () => ({
+	runCleanup: vi.fn(),
+	purgeAllAppCaches: vi.fn(),
 }));
 
 vi.mock("../lib/db.js", () => ({
@@ -38,9 +39,9 @@ vi.mock("../lib/auth.js", () => ({
 }));
 
 import { del, get, set } from "../lib/cache.js";
-import { executeCommand } from "../lib/executor.js";
 import { insertAuditLog } from "../lib/db.js";
 import { getServerHealth } from "../lib/server.js";
+import { purgeAllAppCaches, runCleanup } from "../lib/server-maintenance.js";
 import { registerServerRoutes } from "./server.js";
 
 function createTestApp() {
@@ -67,7 +68,6 @@ describe("Server routes", () => {
 
 	beforeEach(() => {
 		vi.resetAllMocks();
-		vi.mocked(executeCommand).mockReset();
 		vi.mocked(get).mockReturnValue(undefined);
 		app = createTestApp();
 	});
@@ -96,7 +96,7 @@ describe("Server routes", () => {
 
 	describe("POST /api/server/cleanup", () => {
 		it("should run dokku cleanup for operators", async () => {
-			vi.mocked(executeCommand).mockResolvedValue({
+			vi.mocked(runCleanup).mockResolvedValue({
 				command: "dokku cleanup",
 				exitCode: 0,
 				stdout: "Cleanup complete",
@@ -114,7 +114,7 @@ describe("Server routes", () => {
 				stdout: "Cleanup complete",
 				stderr: "",
 			});
-			expect(executeCommand).toHaveBeenCalledWith("dokku cleanup", 120000, { userId: "1" });
+			expect(runCleanup).toHaveBeenCalledWith("1");
 			expect(insertAuditLog).toHaveBeenCalledWith(
 				1,
 				"server:cleanup",
@@ -130,11 +130,11 @@ describe("Server routes", () => {
 
 			expect(response.status).toBe(403);
 			expect(response.body).toEqual({ error: "Forbidden" });
-			expect(executeCommand).not.toHaveBeenCalled();
+			expect(runCleanup).not.toHaveBeenCalled();
 		});
 
 		it("should return command errors on failure", async () => {
-			vi.mocked(executeCommand).mockResolvedValue({
+			vi.mocked(runCleanup).mockResolvedValue({
 				command: "dokku cleanup",
 				exitCode: 1,
 				stdout: "",
@@ -157,32 +157,7 @@ describe("Server routes", () => {
 
 	describe("POST /api/server/purge-cache", () => {
 		it("should purge all app caches for operators", async () => {
-			vi.mocked(executeCommand)
-				.mockResolvedValueOnce({
-					command: "dokku --quiet apps:list",
-					exitCode: 0,
-					stdout: "app-one\napp-two",
-					stderr: "",
-				})
-				.mockResolvedValueOnce({
-					command: "dokku repo:purge-cache app-one",
-					exitCode: 0,
-					stdout: "Purged app-one",
-					stderr: "",
-				})
-				.mockResolvedValueOnce({
-					command: "dokku repo:purge-cache app-two",
-					exitCode: 0,
-					stdout: "Purged app-two",
-					stderr: "",
-				});
-
-			const response = await request(app)
-				.post("/api/server/purge-cache")
-				.set("x-test-role", "operator");
-
-			expect(response.status).toBe(200);
-			expect(response.body).toEqual({
+			vi.mocked(purgeAllAppCaches).mockResolvedValue({
 				command: "dokku repo:purge-cache --all-apps",
 				exitCode: 0,
 				stdout: "Purged app-one\nPurged app-two",
@@ -204,16 +179,13 @@ describe("Server routes", () => {
 					},
 				],
 			});
-			expect(executeCommand).toHaveBeenCalledTimes(3);
-			expect(executeCommand).toHaveBeenNthCalledWith(1, "dokku --quiet apps:list", 30000, {
-				userId: "1",
-			});
-			expect(executeCommand).toHaveBeenNthCalledWith(2, "dokku repo:purge-cache app-one", 120000, {
-				userId: "1",
-			});
-			expect(executeCommand).toHaveBeenNthCalledWith(3, "dokku repo:purge-cache app-two", 120000, {
-				userId: "1",
-			});
+
+			const response = await request(app)
+				.post("/api/server/purge-cache")
+				.set("x-test-role", "operator");
+
+			expect(response.status).toBe(200);
+			expect(purgeAllAppCaches).toHaveBeenCalledWith("1");
 			expect(insertAuditLog).toHaveBeenCalledWith(
 				1,
 				"server:purge-cache",
@@ -231,64 +203,27 @@ describe("Server routes", () => {
 
 			expect(response.status).toBe(403);
 			expect(response.body).toEqual({ error: "Forbidden" });
-			expect(executeCommand).not.toHaveBeenCalled();
+			expect(purgeAllAppCaches).not.toHaveBeenCalled();
 		});
 
-		it("should return an error when app listing fails without running purge commands", async () => {
-			vi.mocked(executeCommand)
-				.mockResolvedValueOnce({
-					command: "dokku --quiet apps:list",
-					exitCode: 1,
-					stdout: "",
-					stderr: "quiet list failed",
-				})
-				.mockResolvedValueOnce({
-					command: "dokku apps:list",
-					exitCode: 1,
-					stdout: "",
-					stderr: "apps list failed",
-				});
-
-			const response = await request(app).post("/api/server/purge-cache");
-
-			expect(response.status).toBe(500);
-			expect(response.body).toEqual({
+		it("should return an error when purge fails without auditing success", async () => {
+			vi.mocked(purgeAllAppCaches).mockResolvedValue({
 				command: "dokku repo:purge-cache --all-apps",
 				exitCode: 1,
 				stdout: "",
 				stderr: "apps list failed",
 				results: [],
 			});
-			expect(executeCommand).toHaveBeenCalledTimes(2);
+
+			const response = await request(app).post("/api/server/purge-cache");
+
+			expect(response.status).toBe(500);
 			expect(insertAuditLog).not.toHaveBeenCalled();
 			expect(del).not.toHaveBeenCalled();
 		});
 
 		it("should return aggregate failure when one app purge fails", async () => {
-			vi.mocked(executeCommand)
-				.mockResolvedValueOnce({
-					command: "dokku --quiet apps:list",
-					exitCode: 0,
-					stdout: "app-one\napp-two",
-					stderr: "",
-				})
-				.mockResolvedValueOnce({
-					command: "dokku repo:purge-cache app-one",
-					exitCode: 0,
-					stdout: "Purged app-one",
-					stderr: "",
-				})
-				.mockResolvedValueOnce({
-					command: "dokku repo:purge-cache app-two",
-					exitCode: 1,
-					stdout: "",
-					stderr: "purge failed",
-				});
-
-			const response = await request(app).post("/api/server/purge-cache");
-
-			expect(response.status).toBe(500);
-			expect(response.body).toEqual({
+			vi.mocked(purgeAllAppCaches).mockResolvedValue({
 				command: "dokku repo:purge-cache --all-apps",
 				exitCode: 1,
 				stdout: "Purged app-one",
@@ -310,6 +245,10 @@ describe("Server routes", () => {
 					},
 				],
 			});
+
+			const response = await request(app).post("/api/server/purge-cache");
+
+			expect(response.status).toBe(500);
 			expect(insertAuditLog).not.toHaveBeenCalled();
 			expect(del).not.toHaveBeenCalled();
 		});

--- a/server/routes/server.ts
+++ b/server/routes/server.ts
@@ -1,13 +1,79 @@
 import type express from "express";
+import { stripAnsi } from "../lib/ansi.js";
+import { isValidAppName } from "../lib/apps.js";
 import { getServerHealth, type ServerHealth } from "../lib/server.js";
 import { authMiddleware, requireOperator } from "../lib/auth.js";
 import { del, get, set } from "../lib/cache.js";
-import { executeCommand } from "../lib/executor.js";
+import { type CommandResult, executeCommand } from "../lib/executor.js";
 import { DokkuCommands } from "../lib/dokku.js";
 import { getStatusCode, getUserId, handleCommandResult, safeAuditLog } from "./util.js";
 
 const HEALTH_CACHE_KEY = "server:health";
 const CLEANUP_TIMEOUT_MS = 120000;
+const PURGE_AGGREGATE_COMMAND = "dokku repo:purge-cache --all-apps";
+
+interface PurgeCacheResult extends CommandResult {
+	results: Array<CommandResult & { app: string }>;
+}
+
+async function listAppNames(userId?: string): Promise<string[] | CommandResult> {
+	const listCommands = [DokkuCommands.appsListQuiet(), DokkuCommands.appsList()];
+	let listResult: CommandResult | undefined;
+
+	for (const command of listCommands) {
+		const result = await executeCommand(command, 30000, { userId });
+		if (result.exitCode === 0) {
+			return result.stdout
+				.split("\n")
+				.map((line) => stripAnsi(line).trim())
+				.filter(isValidAppName);
+		}
+		listResult = result;
+	}
+
+	return {
+		command: listResult?.command || DokkuCommands.appsList(),
+		exitCode: listResult?.exitCode || 1,
+		stdout: "",
+		stderr: listResult?.stderr || "Failed to list apps",
+	};
+}
+
+async function purgeAllAppCaches(userId?: string): Promise<PurgeCacheResult> {
+	const appNamesResult = await listAppNames(userId);
+	if (!Array.isArray(appNamesResult)) {
+		return {
+			command: PURGE_AGGREGATE_COMMAND,
+			exitCode: appNamesResult.exitCode,
+			stdout: "",
+			stderr: appNamesResult.stderr,
+			results: [],
+		};
+	}
+
+	const results: Array<CommandResult & { app: string }> = [];
+	for (const app of appNamesResult) {
+		const result = await executeCommand(DokkuCommands.repoPurgeCache(app), CLEANUP_TIMEOUT_MS, {
+			userId,
+		});
+		results.push({ ...result, app });
+	}
+
+	const failedResults = results.filter((result) => result.exitCode !== 0);
+	return {
+		command: PURGE_AGGREGATE_COMMAND,
+		exitCode: failedResults.length > 0 ? 1 : 0,
+		stdout: results
+			.map((result) => result.stdout)
+			.filter(Boolean)
+			.join("\n"),
+		stderr: failedResults
+			.map((result) => result.stderr)
+			.filter(Boolean)
+			.join("\n"),
+		results,
+	};
+}
 
 export function registerServerRoutes(app: express.Application): void {
 	app.get("/api/server/health", authMiddleware, async (_req, res) => {
@@ -37,6 +103,23 @@ export function registerServerRoutes(app: express.Application): void {
 			}
 
 			safeAuditLog(req, "server:cleanup", null);
+			del(HEALTH_CACHE_KEY);
+			res.json(result);
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	app.post("/api/server/purge-cache", authMiddleware, requireOperator, async (req, res, next) => {
+		try {
+			const userId = getUserId(req);
+			const result = await purgeAllAppCaches(userId);
+
+			if (!handleCommandResult(res, result)) {
+				return;
+			}
+
+			safeAuditLog(req, "server:purge-cache", null);
 			del(HEALTH_CACHE_KEY);
 			res.json(result);
 		} catch (error) {

--- a/server/routes/server.ts
+++ b/server/routes/server.ts
@@ -1,78 +1,41 @@
 import type express from "express";
-import { stripAnsi } from "../lib/ansi.js";
-import { isValidAppName } from "../lib/apps.js";
 import { getServerHealth, type ServerHealth } from "../lib/server.js";
+import { purgeAllAppCaches, runCleanup } from "../lib/server-maintenance.js";
 import { authMiddleware, requireOperator } from "../lib/auth.js";
 import { del, get, set } from "../lib/cache.js";
-import { type CommandResult, executeCommand } from "../lib/executor.js";
-import { DokkuCommands } from "../lib/dokku.js";
-import { getStatusCode, getUserId, handleCommandResult, safeAuditLog } from "./util.js";
+import {
+	getStatusCode,
+	getUserId,
+	handleCommandResult,
+	safeAuditLog,
+	type CommandResultLike,
+} from "./util.js";
 
 const HEALTH_CACHE_KEY = "server:health";
-const CLEANUP_TIMEOUT_MS = 120000;
-const PURGE_AGGREGATE_COMMAND = "dokku repo:purge-cache --all-apps";
 
-interface PurgeCacheResult extends CommandResult {
-	results: Array<CommandResult & { app: string }>;
-}
+async function runServerMaintenanceAction(
+	req: express.Request,
+	res: express.Response,
+	next: express.NextFunction,
+	options: {
+		run: (userId: string | undefined) => Promise<CommandResultLike>;
+		auditAction: string;
+	}
+): Promise<void> {
+	try {
+		const userId = getUserId(req);
+		const result = await options.run(userId);
 
-async function listAppNames(userId?: string): Promise<string[] | CommandResult> {
-	const listCommands = [DokkuCommands.appsListQuiet(), DokkuCommands.appsList()];
-	let listResult: CommandResult | undefined;
-
-	for (const command of listCommands) {
-		const result = await executeCommand(command, 30000, { userId });
-		if (result.exitCode === 0) {
-			return result.stdout
-				.split("\n")
-				.map((line) => stripAnsi(line).trim())
-				.filter(isValidAppName);
+		if (!handleCommandResult(res, result)) {
+			return;
 		}
-		listResult = result;
+
+		safeAuditLog(req, options.auditAction, null);
+		del(HEALTH_CACHE_KEY);
+		res.json(result);
+	} catch (error) {
+		next(error);
 	}
-
-	return {
-		command: listResult?.command || DokkuCommands.appsList(),
-		exitCode: listResult?.exitCode || 1,
-		stdout: "",
-		stderr: listResult?.stderr || "Failed to list apps",
-	};
-}
-
-async function purgeAllAppCaches(userId?: string): Promise<PurgeCacheResult> {
-	const appNamesResult = await listAppNames(userId);
-	if (!Array.isArray(appNamesResult)) {
-		return {
-			command: PURGE_AGGREGATE_COMMAND,
-			exitCode: appNamesResult.exitCode,
-			stdout: "",
-			stderr: appNamesResult.stderr,
-			results: [],
-		};
-	}
-
-	const results: Array<CommandResult & { app: string }> = [];
-	for (const app of appNamesResult) {
-		const result = await executeCommand(DokkuCommands.repoPurgeCache(app), CLEANUP_TIMEOUT_MS, {
-			userId,
-		});
-		results.push({ ...result, app });
-	}
-
-	const failedResults = results.filter((result) => result.exitCode !== 0);
-	return {
-		command: PURGE_AGGREGATE_COMMAND,
-		exitCode: failedResults.length > 0 ? 1 : 0,
-		stdout: results
-			.map((result) => result.stdout)
-			.filter(Boolean)
-			.join("\n"),
-		stderr: failedResults
-			.map((result) => result.stderr)
-			.filter(Boolean)
-			.join("\n"),
-		results,
-	};
 }
 
 export function registerServerRoutes(app: express.Application): void {
@@ -93,37 +56,17 @@ export function registerServerRoutes(app: express.Application): void {
 		res.json(health);
 	});
 
-	app.post("/api/server/cleanup", authMiddleware, requireOperator, async (req, res, next) => {
-		try {
-			const userId = getUserId(req);
-			const result = await executeCommand(DokkuCommands.cleanup(), CLEANUP_TIMEOUT_MS, { userId });
+	app.post("/api/server/cleanup", authMiddleware, requireOperator, (req, res, next) =>
+		runServerMaintenanceAction(req, res, next, {
+			run: runCleanup,
+			auditAction: "server:cleanup",
+		})
+	);
 
-			if (!handleCommandResult(res, result)) {
-				return;
-			}
-
-			safeAuditLog(req, "server:cleanup", null);
-			del(HEALTH_CACHE_KEY);
-			res.json(result);
-		} catch (error) {
-			next(error);
-		}
-	});
-
-	app.post("/api/server/purge-cache", authMiddleware, requireOperator, async (req, res, next) => {
-		try {
-			const userId = getUserId(req);
-			const result = await purgeAllAppCaches(userId);
-
-			if (!handleCommandResult(res, result)) {
-				return;
-			}
-
-			safeAuditLog(req, "server:purge-cache", null);
-			del(HEALTH_CACHE_KEY);
-			res.json(result);
-		} catch (error) {
-			next(error);
-		}
-	});
+	app.post("/api/server/purge-cache", authMiddleware, requireOperator, (req, res, next) =>
+		runServerMaintenanceAction(req, res, next, {
+			run: purgeAllAppCaches,
+			auditAction: "server:purge-cache",
+		})
+	);
 }


### PR DESCRIPTION
## What

Add a second server cleanup action for operators and admins: **Purge build caches**, exposed from the Server Health card when disk status is warning or critical.

- **Server:** `DokkuCommands.repoPurgeCache(app)` and `POST /api/server/purge-cache` — lists all apps, runs `dokku repo:purge-cache` sequentially, returns aggregate per-app results
- **Client:** `PurgeCacheResultSchema`, React Query mutation, and a conditional **Purge build caches** button with its own confirmation dialog
- **Docs:** README feature list, server command table, and `docs/deployment.md` two-tier disk recovery guidance

## Why

When disk pressure persists after `dokku cleanup`, build caches across apps are a common next recovery step. Operators currently need SSH to run `repo:purge-cache` per app. This adds a safe, audited dashboard action for that second tier without running `repo:gc` or removing volumes.

## How

- Route is protected by `authMiddleware` + `requireOperator`; app names are parsed from `dokku --quiet apps:list` (fallback to `apps:list`) and validated with `isValidAppName`
- Purges run sequentially with the existing 120s cleanup timeout; aggregate `exitCode` is 1 if any app fails (HTTP 500), with per-app `results` included for troubleshooting
- Audit (`server:purge-cache`) and `server:health` cache invalidation happen only when all app purges succeed, matching the existing cleanup route pattern
- UI button is shown only when `canModify` is true and `health.resources.disk.status` is `warning` or `critical`

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)