### PR TITLE
feat: add one-line uninstall script for Docklight + Dokku

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,24 @@ git push dokku main
 
 Full guide: [docs/deployment.md](docs/deployment.md)
 
+### Uninstall
+
+To completely remove Docklight, Dokku, and all associated data from a VPS, run as root:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh | sudo bash
+```
+
+The script stops the Docklight app, removes the auto-update timer (if any), destroys the Dokku app, purges Dokku and herokuish packages, removes `/home/dokku`, `/var/lib/dokku`, and `/var/log/dokku`, and deletes the `dokku` user.
+
+**WARNING:** This is destructive — it removes all apps, databases, SSL certs, and configs. Interactive confirmation is required unless `CONFIRM=1` is set.
+
+| Variable        | Description                             | Default     |
+| --------------- | --------------------------------------- | ----------- |
+| `APP_NAME`      | Dokku app name to destroy               | `docklight` |
+| `REMOVE_DOCKER` | Also purge Docker (`1`/`0`)             | `0`         |
+| `CONFIRM`       | Skip interactive confirmation (`1`/`0`) | `0`         |
+
 #### From Source (Local Development)
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -888,6 +888,57 @@ git remote add staging dokku@<your-server-ip>:docklight-staging
 git push staging your-branch:main --force
 ```
 
+## Uninstall
+
+To completely remove Docklight, Dokku, and all associated data from a VPS, run `scripts/uninstall.sh` as root:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh | sudo bash
+```
+
+**WARNING:** This is destructive and irreversible. It removes all Dokku apps, databases, SSL certs, and configs. The script requests interactive confirmation (`yes`/`NO`) before proceeding.
+
+### What it removes
+
+1. **Docklight app** — stopped and destroyed via `dokku apps:destroy`
+2. **Auto-update timer** — systemd timer and service files removed
+3. **Dokku packages** — `dokku` and `herokuish` purged via `apt-get purge`
+4. **Dokku data** — `/home/dokku`, `/var/lib/dokku`, `/var/log/dokku` deleted
+5. **Dokku user** — system user and group removed
+6. **Docker artifacts** — any remaining containers and volumes matching `APP_NAME`
+
+Docker itself is **preserved** by default. Pass `REMOVE_DOCKER=1` to also purge Docker packages and delete `/var/lib/docker`.
+
+### Environment variables
+
+| Variable        | Description                             | Default     |
+| --------------- | --------------------------------------- | ----------- |
+| `APP_NAME`      | Dokku app name to destroy               | `docklight` |
+| `REMOVE_DOCKER` | Also purge Docker (`1`/`0`)             | `0`         |
+| `CONFIRM`       | Skip interactive confirmation (`1`/`0`) | `0`         |
+
+### Examples
+
+**Default uninstall (interactive):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh | sudo bash
+```
+
+**Non-interactive uninstall with a custom app name:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh \
+  | sudo APP_NAME=my-docklight CONFIRM=1 bash
+```
+
+**Full purge including Docker:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh \
+  | sudo REMOVE_DOCKER=1 CONFIRM=1 bash
+```
+
 ## Security Recommendations
 
 1. **Always use HTTPS** — Enable Let's Encrypt (Step 5)

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -44,7 +44,7 @@ if [[ "${CONFIRM}" != "1" ]]; then
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   DESTRUCTIVE OPERATION — This will remove everything:
     - Dokku, all apps, databases, SSL certs
-    - Docker containers, images, volumes${REMOVE_DOCKER:+ (Docker will also be purged)}
+    - Docker containers, images, volumes$([[ "${REMOVE_DOCKER}" == "1" ]] && printf ' (Docker will also be purged)')
     - /home/dokku, /var/lib/dokku, /var/log/dokku
   Type "yes" to continue or Ctrl+C to abort.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -9,7 +9,6 @@
 #
 # Environment variables (all optional):
 #   APP_NAME        Dokku app name to destroy            (default: docklight)
-#   REMOVE_DOCKER   Also purge Docker (1/0)              (default: 0)
 #   CONFIRM         Skip interactive confirmation (1/0)   (default: 0)
 #
 # WARNING: This script is DESTRUCTIVE. It will remove ALL Dokku data including
@@ -18,7 +17,6 @@
 set -euo pipefail
 
 APP_NAME="${APP_NAME:-docklight}"
-REMOVE_DOCKER="${REMOVE_DOCKER:-0}"
 CONFIRM="${CONFIRM:-0}"
 
 # ---------- helpers ----------
@@ -44,7 +42,7 @@ if [[ "${CONFIRM}" != "1" ]]; then
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   DESTRUCTIVE OPERATION — This will remove everything:
     - Dokku, all apps, databases, SSL certs
-    - Docker containers, images, volumes$([[ "${REMOVE_DOCKER}" == "1" ]] && printf ' (Docker will also be purged)')
+    - Docker containers, images, volumes
     - /home/dokku, /var/lib/dokku, /var/log/dokku
   Type "yes" to continue or Ctrl+C to abort.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -91,35 +89,18 @@ log "Purging dokku and herokuish packages..."
 apt-get purge -y dokku herokuish 2>/dev/null || true
 apt-get autoremove -y 2>/dev/null || true
 
-# ---------- 6. Optionally remove Docker ----------
-if [[ "${REMOVE_DOCKER}" == "1" ]]; then
-	log "Removing Docker..."
-	apt-get purge -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin 2>/dev/null || true
-	rm -rf /var/lib/docker
-fi
-
-# ---------- 7. Remove Dokku data directories ----------
+# ---------- 6. Remove Dokku data directories ----------
 log "Removing Dokku data directories..."
 rm -rf /home/dokku
 rm -rf /var/lib/dokku
 rm -rf /var/log/dokku
 
-# ---------- 8. Remove dokku user and group ----------
+# ---------- 7. Remove dokku user and group ----------
 log "Removing dokku user and group..."
 deluser dokku 2>/dev/null || true
 delgroup dokku 2>/dev/null || true
 
-# ---------- 9. Remove any remaining docklight-specific Docker artifacts ----------
-log "Removing any remaining Docker artifacts for '${APP_NAME}'..."
-if command -v docker >/dev/null 2>&1; then
-	docker ps -a -q --filter "name=${APP_NAME}" 2>/dev/null | xargs -r docker rm -f 2>/dev/null || true
-	docker volume ls -q --filter "name=${APP_NAME}" 2>/dev/null | xargs -r docker volume rm -f 2>/dev/null || true
-fi
-
 # ---------- done ----------
-DOCKER_MSG="preserved"
-[[ "${REMOVE_DOCKER}" == "1" ]] && DOCKER_MSG="purged"
-
 cat <<EOF
 
 ============================================================
@@ -130,7 +111,8 @@ cat <<EOF
     - App:         ${APP_NAME}
     - Dokku:       purged (packages + all data)
     - Auto-update: timer removed
-    - Docker:      ${DOCKER_MSG}
+
+  Docker was left untouched.
 
   To reinstall, visit:
     https://github.com/jellydn/docklight

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -48,7 +48,7 @@ if [[ "${CONFIRM}" != "1" ]]; then
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 WARN
-	read -r -p "Continue? [yes/NO]: " REPLY
+	read -r -p "Continue? [yes/NO]: " REPLY < /dev/tty
 	if [[ "${REPLY}" != "yes" ]]; then
 		log "Aborted."
 		exit 0
@@ -94,6 +94,7 @@ log "Removing Dokku data directories..."
 rm -rf /home/dokku
 rm -rf /var/lib/dokku
 rm -rf /var/log/dokku
+rm -rf /etc/dokku
 
 # ---------- 7. Remove dokku user and group ----------
 log "Removing dokku user and group..."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Docklight one-line uninstaller
+#
+# Completely removes Docklight, Dokku, and all associated data from a VPS.
+#
+# Usage (run as root on the VPS):
+#   curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh | sudo bash
+#
+# Environment variables (all optional):
+#   APP_NAME        Dokku app name to destroy            (default: docklight)
+#   REMOVE_DOCKER   Also purge Docker (1/0)              (default: 0)
+#   CONFIRM         Skip interactive confirmation (1/0)   (default: 0)
+#
+# WARNING: This script is DESTRUCTIVE. It will remove ALL Dokku data including
+#          apps, databases, SSL certs, and configs. Use with extreme care.
+
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-docklight}"
+REMOVE_DOCKER="${REMOVE_DOCKER:-0}"
+CONFIRM="${CONFIRM:-0}"
+
+# ---------- helpers ----------
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+err() {
+	printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2
+	exit 1
+}
+
+require_root() {
+	if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+		err "This uninstaller must be run as root (try: sudo bash)"
+	fi
+}
+
+# ---------- preflight ----------
+require_root
+
+if [[ "${CONFIRM}" != "1" ]]; then
+	cat <<WARN
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  DESTRUCTIVE OPERATION — This will remove everything:
+    - Dokku, all apps, databases, SSL certs
+    - Docker containers, images, volumes${REMOVE_DOCKER:+ (Docker will also be purged)}
+    - /home/dokku, /var/lib/dokku, /var/log/dokku
+  Type "yes" to continue or Ctrl+C to abort.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+WARN
+	read -r -p "Continue? [yes/NO]: " REPLY
+	if [[ "${REPLY}" != "yes" ]]; then
+		log "Aborted."
+		exit 0
+	fi
+fi
+
+# ---------- 1. Stop Docklight app ----------
+if command -v dokku >/dev/null 2>&1; then
+	if dokku apps:exists "${APP_NAME}" >/dev/null 2>&1; then
+		log "Stopping app '${APP_NAME}'..."
+		dokku ps:stop "${APP_NAME}" 2>/dev/null || true
+	fi
+fi
+
+# ---------- 2. Remove auto-update timer (if installed) ----------
+log "Removing auto-update timer (if any)..."
+systemctl stop "${APP_NAME}-update.timer" 2>/dev/null || true
+systemctl disable "${APP_NAME}-update.timer" 2>/dev/null || true
+rm -f "/etc/systemd/system/${APP_NAME}-update.service"
+rm -f "/etc/systemd/system/${APP_NAME}-update.timer"
+rm -f "/usr/local/bin/${APP_NAME}-update"
+systemctl daemon-reload 2>/dev/null || true
+
+# ---------- 3. Destroy the Docklight Dokku app ----------
+if command -v dokku >/dev/null 2>&1; then
+	if dokku apps:exists "${APP_NAME}" >/dev/null 2>&1; then
+		log "Destroying app '${APP_NAME}'..."
+		dokku apps:destroy "${APP_NAME}" --force 2>/dev/null || dokku apps:destroy "${APP_NAME}" 2>/dev/null || true
+	fi
+
+	# ---------- 4. Dokku cleanup (remove dangling containers/images) ----------
+	log "Running Dokku cleanup..."
+	dokku cleanup 2>/dev/null || true
+fi
+
+# ---------- 5. Uninstall Dokku & herokuish packages ----------
+log "Purging dokku and herokuish packages..."
+apt-get purge -y dokku herokuish 2>/dev/null || true
+apt-get autoremove -y 2>/dev/null || true
+
+# ---------- 6. Optionally remove Docker ----------
+if [[ "${REMOVE_DOCKER}" == "1" ]]; then
+	log "Removing Docker..."
+	apt-get purge -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin 2>/dev/null || true
+	rm -rf /var/lib/docker
+fi
+
+# ---------- 7. Remove Dokku data directories ----------
+log "Removing Dokku data directories..."
+rm -rf /home/dokku
+rm -rf /var/lib/dokku
+rm -rf /var/log/dokku
+
+# ---------- 8. Remove dokku user and group ----------
+log "Removing dokku user and group..."
+deluser dokku 2>/dev/null || true
+delgroup dokku 2>/dev/null || true
+
+# ---------- 9. Remove any remaining docklight-specific Docker artifacts ----------
+log "Removing any remaining Docker artifacts for '${APP_NAME}'..."
+if command -v docker >/dev/null 2>&1; then
+	docker ps -a -q --filter "name=${APP_NAME}" 2>/dev/null | xargs -r docker rm -f 2>/dev/null || true
+	docker volume ls -q --filter "name=${APP_NAME}" 2>/dev/null | xargs -r docker volume rm -f 2>/dev/null || true
+fi
+
+# ---------- done ----------
+DOCKER_MSG="preserved"
+[[ "${REMOVE_DOCKER}" == "1" ]] && DOCKER_MSG="purged"
+
+cat <<EOF
+
+============================================================
+  ✅ Uninstall complete
+============================================================
+
+  Removed:
+    - App:         ${APP_NAME}
+    - Dokku:       purged (packages + all data)
+    - Auto-update: timer removed
+    - Docker:      ${DOCKER_MSG}
+
+  To reinstall, visit:
+    https://github.com/jellydn/docklight
+
+EOF

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -89,6 +89,15 @@ fi
 # ---------- 5. Uninstall Dokku & herokuish packages ----------
 log "Purging dokku and herokuish packages..."
 apt-get purge -y dokku herokuish 2>/dev/null || true
+
+# Mark Docker packages as manually installed so autoremove doesn't nuke them.
+# Dokku installs Docker as a dependency; without this, purging Dokku would
+# cause autoremove to remove Docker too.
+if command -v apt-mark >/dev/null 2>&1; then
+	dpkg -l 2>/dev/null \
+		| awk '/^ii/ && $2 ~ /^(docker|containerd\.io)/ {print $2}' \
+		| xargs -r apt-mark manual 2>/dev/null || true
+fi
 apt-get autoremove -y 2>/dev/null || true
 
 # ---------- 6. Remove Dokku data directories ----------

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -40,10 +40,12 @@ if [[ "${CONFIRM}" != "1" ]]; then
 	cat <<WARN
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  DESTRUCTIVE OPERATION — This will remove everything:
-    - Dokku, all apps, databases, SSL certs
-    - Docker containers, images, volumes
-    - /home/dokku, /var/lib/dokku, /var/log/dokku
+  DESTRUCTIVE OPERATION — This will remove:
+    - Dokku: all apps, databases, SSL certs, packages, config
+    - Docker images/containers created by Dokku (not Docker itself)
+    - /home/dokku, /var/lib/dokku, /var/log/dokku, /etc/dokku
+
+  Docker engine and your other containers will be left untouched.
   Type "yes" to continue or Ctrl+C to abort.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
## What

Add `scripts/uninstall.sh` — a one-line uninstall script that cleanly removes Docklight and Dokku from a VPS while leaving the Docker engine and all non-Dokku containers entirely untouched.

## Why

Users who installed Docklight via the one-line installer had no way to cleanly remove everything when decommissioning a VPS or starting fresh. Previously this required manually tracking down Dokku packages, data directories, SSH keys, systemd timers, and Docker artifacts — error-prone and incomplete. This script mirrors the install experience: one curl pipe to wipe everything.

## How

- Created `scripts/uninstall.sh` following the same conventions as the existing `scripts/install.sh`
- **Removes only Docklight + Dokku** — Docker engine and other containers are left untouched
- Stops and destroys the Docklight Dokku app, which removes the associated containers/images
- Removes auto-update systemd timer (if installed)
- Purges `dokku` and `herokuish` packages + orphaned deps via `apt-get autoremove`
- Protects Docker packages from autoremove by marking them as manually installed with `apt-mark manual`
- Deletes Dokku data: `/home/dokku`, `/var/lib/dokku`, `/var/log/dokku`, `/etc/dokku`
- Removes `dokku` user and group
- Includes safety confirmation prompt (bypass with `CONFIRM=1`)
- Compatible with piped execution (`curl | sudo bash`) via `read < /dev/tty`

## Fixes Applied During Review

1. **Docker preserved from autoremove** — `apt-get autoremove` was inadvertently removing Docker packages because they were installed as Dokku dependencies. Added `dpkg -l | awk ... | xargs apt-mark manual` to mark all installed Docker/containerd packages as manually installed before running autoremove.
2. **Clarified warning message** — Now explicitly says "Docker images/containers created by Dokku (not Docker itself)" and "Docker engine and your other containers will be left untouched" instead of the misleading "Docker containers, images, volumes".
3. **Piped stdin fix** — Added `read < /dev/tty` so the confirmation prompt works when the script is piped via `curl | sudo bash`.
4. **Added `/etc/dokku` cleanup** — Dokku config files persist there after package purge.
5. **Removed REMOVE_DOCKER option** — Simplified scope to only removing Docklight/Dokku.

## Env Vars

| Var | Default | Description |
|-----|---------|-------------|
| `APP_NAME` | `docklight` | App to destroy |
| `CONFIRM` | `0` | Set to `1` to skip interactive confirmation |

## Usage

```bash
curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/uninstall.sh | sudo bash
```
