### PR TITLE
feat: add email support and password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ just build
 | `DOCKLIGHT_COMMAND_WINDOW_MS`       | No                             | Command rate limit window in ms (default `60000` = 1 min)                                                     |
 | `DOCKLIGHT_COMMAND_MAX_REQUESTS`    | No                             | Max command executions per window per user (default `30`, dev: `1000`)                                        |
 | `DOCKLIGHT_ADMIN_MAX_REQUESTS`      | No                             | Max admin API requests per window (default `30`, dev: `1000`)                                                 |
-| `DOCKLIGHT_APP_URL`                 | No                             | App URL used to build password reset links (e.g. `https://docklight.example.com`)                             |
+| `DOCKLIGHT_APP_URL`                 | Yes (if reset email enabled)   | App URL used to build password reset links (e.g. `https://docklight.example.com`). Required when `RESEND_API_KEY` is configured. |
 | `RESEND_API_KEY`                    | No                             | API key for Resend email delivery service (required for password reset emails)                                |
 | `RESEND_FROM_EMAIL`                 | No                             | Sender email address for password reset emails (e.g. `Docklight <no-reply@yourdomain.com>`)                    |
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ just build
 | `DOCKLIGHT_COMMAND_WINDOW_MS`       | No                             | Command rate limit window in ms (default `60000` = 1 min)                                                     |
 | `DOCKLIGHT_COMMAND_MAX_REQUESTS`    | No                             | Max command executions per window per user (default `30`, dev: `1000`)                                        |
 | `DOCKLIGHT_ADMIN_MAX_REQUESTS`      | No                             | Max admin API requests per window (default `30`, dev: `1000`)                                                 |
+| `DOCKLIGHT_APP_URL`                 | No                             | App URL used to build password reset links (e.g. `https://docklight.example.com`)                             |
+| `RESEND_API_KEY`                    | No                             | API key for Resend email delivery service (required for password reset emails)                                |
+| `RESEND_FROM_EMAIL`                 | No                             | Sender email address for password reset emails (e.g. `Docklight <no-reply@yourdomain.com>`)                    |
 
 ### One-line installer env vars
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { RequireAdmin } from "./components/RequireAdmin";
 import { ToastProvider } from "./components/ToastProvider";
 import { AuthProvider } from "./contexts/auth-context.js";
 import { Login } from "./pages/Login";
+import { ResetPassword } from "./pages/ResetPassword";
 
 const Dashboard = lazy(() => import("./pages/Dashboard").then((m) => ({ default: m.Dashboard })));
 const Apps = lazy(() => import("./pages/Apps").then((m) => ({ default: m.Apps })));
@@ -22,6 +23,7 @@ function App() {
 			<BrowserRouter>
 				<Routes>
 					<Route path="/login" element={<Login />} />
+					<Route path="/reset-password" element={<ResetPassword />} />
 					<Route
 						path="/"
 						element={

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -223,6 +223,7 @@ export type UserRole = z.infer<typeof UserRoleSchema>;
 export const UserSchema = z.object({
 	id: z.number(),
 	username: z.string(),
+	email: z.string().email().nullable().optional(),
 	role: UserRoleSchema,
 	createdAt: z.string(),
 });

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -92,6 +92,14 @@ describe("Login", () => {
 		await user.click(screen.getByRole("button", { name: "Send reset link" }));
 
 		await waitFor(() => {
+			expect(apiFetchMock).toHaveBeenCalledWith(
+				"/auth/forgot-password",
+				expect.any(Object),
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ email: "user@example.com" }),
+				})
+			);
 			expect(screen.getByText("Reset link: /reset-password?token=abc")).toBeInTheDocument();
 		});
 	});

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -34,7 +34,6 @@ describe("Login", () => {
 		vi.clearAllMocks();
 		const { apiFetch } = await import("../lib/api.js");
 		apiFetchMock = apiFetch as MockedFunction<typeof apiFetch>;
-		// Default: auth/me fails (not logged in)
 		apiFetchMock.mockImplementation((path: string) => {
 			if (path === "/auth/me") return Promise.reject(new Error("Unauthorized"));
 			return Promise.reject(new Error("Not found"));
@@ -48,6 +47,7 @@ describe("Login", () => {
 		expect(screen.getByLabelText("Username")).toBeInTheDocument();
 		expect(screen.getByLabelText("Password")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Forgot password?" })).toBeInTheDocument();
 	});
 
 	it("should show error message on failed login", async () => {
@@ -71,6 +71,28 @@ describe("Login", () => {
 
 		await waitFor(() => {
 			expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+		});
+	});
+
+	it("should request a password reset link", async () => {
+		apiFetchMock.mockImplementation((path: string) => {
+			if (path === "/auth/me") return Promise.reject(new Error("Unauthorized"));
+			if (path === "/auth/forgot-password") {
+				return Promise.resolve({ success: true, resetUrl: "/reset-password?token=abc" });
+			}
+			return Promise.reject(new Error("Not found"));
+		});
+
+		const user = userEvent.setup();
+		renderWithQueryClient(<Login />);
+
+		await screen.findByText("Docklight Login");
+		await user.click(screen.getByRole("button", { name: "Forgot password?" }));
+		await user.type(screen.getByLabelText("Email"), "user@example.com");
+		await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Reset link: /reset-password?token=abc")).toBeInTheDocument();
 		});
 	});
 

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -9,6 +9,15 @@ vi.mock("../lib/api.js", () => ({
 	apiFetch: vi.fn(),
 }));
 
+const mockToastContext = {
+	addToast: vi.fn(),
+	removeToast: vi.fn(),
+};
+
+vi.mock("../components/ToastProvider", () => ({
+	useToast: () => mockToastContext,
+}));
+
 const createTestQueryClient = () =>
 	new QueryClient({
 		defaultOptions: {
@@ -100,7 +109,10 @@ describe("Login", () => {
 					body: JSON.stringify({ email: "user@example.com" }),
 				})
 			);
-			expect(screen.getByText("Reset link: /reset-password?token=abc")).toBeInTheDocument();
+			expect(mockToastContext.addToast).toHaveBeenCalledWith(
+				"success",
+				expect.stringContaining("sent")
+			);
 		});
 	});
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,10 +7,20 @@ import { Button } from "@/components/ui/button";
 import { queryKeys } from "../lib/query-keys.js";
 import { AuthMeSchema } from "../lib/schemas.js";
 
+const ForgotPasswordSchema = z.object({
+	success: z.literal(true),
+	resetToken: z.string().optional(),
+	resetUrl: z.string().optional(),
+});
+
 export function Login() {
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
+	const [forgotPasswordOpen, setForgotPasswordOpen] = useState(false);
+	const [resetEmail, setResetEmail] = useState("");
+	const [resetMessage, setResetMessage] = useState("");
+	const [resetError, setResetError] = useState("");
 	const navigate = useNavigate();
 
 	const { data: authData, isLoading } = useQuery({
@@ -42,6 +52,26 @@ export function Login() {
 			} else {
 				setError("Invalid credentials");
 			}
+		}
+	};
+
+	const handleForgotPassword = async (e: FormEvent) => {
+		e.preventDefault();
+		setResetError("");
+		setResetMessage("");
+
+		try {
+			const result = await apiFetch("/auth/forgot-password", ForgotPasswordSchema, {
+				method: "POST",
+				body: JSON.stringify({ email: resetEmail }),
+			});
+			if (result.resetUrl) {
+				setResetMessage(`Reset link: ${result.resetUrl}`);
+			} else {
+				setResetMessage("If the email exists, a reset link has been created.");
+			}
+		} catch (err) {
+			setResetError(err instanceof Error ? err.message : "Failed to request reset");
 		}
 	};
 
@@ -94,6 +124,40 @@ export function Login() {
 						Login
 					</Button>
 				</form>
+
+				<div className="mt-4 border-t border-border pt-4">
+					<button
+						type="button"
+						onClick={() => setForgotPasswordOpen((current) => !current)}
+						className="text-sm text-muted-foreground hover:text-foreground"
+					>
+						{forgotPasswordOpen ? "Hide password reset" : "Forgot password?"}
+					</button>
+
+					{forgotPasswordOpen && (
+						<form onSubmit={handleForgotPassword} className="mt-4 space-y-3">
+							<div>
+								<label htmlFor="reset-email" className="block text-sm font-medium mb-2">
+									Email
+								</label>
+								<input
+									id="reset-email"
+									type="email"
+									value={resetEmail}
+									onChange={(e) => setResetEmail(e.target.value)}
+									className="w-full px-3 py-2 border border-border rounded-md"
+									required
+									autoComplete="email"
+								/>
+							</div>
+							{resetError && <div className="text-destructive text-sm">{resetError}</div>}
+							{resetMessage && <div className="text-sm text-foreground">{resetMessage}</div>}
+							<Button type="submit" variant="secondary" className="w-full">
+								Send reset link
+							</Button>
+						</form>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -17,7 +17,7 @@ export function Login(): JSX.Element {
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
-	const [forgotPasswordOpen, setForgotPasswordOpen] = useState(false);
+	const [mode, setMode] = useState<"login" | "forgot-password">("login");
 	const [resetEmail, setResetEmail] = useState("");
 	const [resetMessage, setResetMessage] = useState("");
 	const [resetError, setResetError] = useState("");
@@ -90,59 +90,63 @@ export function Login(): JSX.Element {
 				<div className="flex justify-center mb-4">
 					<img src="/logo.svg" alt="Docklight logo" className="h-12 w-12" />
 				</div>
-				<h1 className="text-2xl font-bold mb-6 text-center">Docklight Login</h1>
-				<form onSubmit={handleSubmit} className="space-y-4">
-					<div>
-						<label htmlFor="username" className="block text-sm font-medium mb-2">
-							Username
-						</label>
-						<input
-							id="username"
-							type="text"
-							value={username}
-							onChange={(e) => setUsername(e.target.value)}
-							className="w-full px-3 py-2 border border-border rounded-md"
-							required
-							autoComplete="username"
-						/>
-					</div>
-					<div>
-						<label htmlFor="password" className="block text-sm font-medium mb-2">
-							Password
-						</label>
-						<input
-							id="password"
-							type="password"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							className="w-full px-3 py-2 border border-border rounded-md"
-							required
-							autoComplete="current-password"
-						/>
-					</div>
-					{error && <div className="text-destructive text-sm">{error}</div>}
-					<Button type="submit" className="w-full">
-						Login
-					</Button>
-				</form>
 
-				<div className="mt-4 border-t border-border pt-4">
-					<button
-						type="button"
-						onClick={() => setForgotPasswordOpen((current) => !current)}
-						aria-expanded={forgotPasswordOpen}
-						aria-controls="forgot-password-form"
-						className="text-sm text-muted-foreground hover:text-foreground"
-					>
-						{forgotPasswordOpen ? "Hide password reset" : "Forgot password?"}
-					</button>
-
-					{forgotPasswordOpen && (
-						<form
-							id="forgot-password-form"
-							onSubmit={handleForgotPassword}
-							className="mt-4 space-y-3"
-						>
+				{mode === "login" ? (
+					<>
+						<h1 className="text-2xl font-bold mb-6 text-center">Docklight Login</h1>
+						<form onSubmit={handleSubmit} className="space-y-4">
+							<div>
+								<label htmlFor="username" className="block text-sm font-medium mb-2">
+									Username
+								</label>
+								<input
+									id="username"
+									type="text"
+									value={username}
+									onChange={(e) => setUsername(e.target.value)}
+									className="w-full px-3 py-2 border border-border rounded-md"
+									required
+									autoComplete="username"
+								/>
+							</div>
+							<div>
+								<label htmlFor="password" className="block text-sm font-medium mb-2">
+									Password
+								</label>
+								<input
+									id="password"
+									type="password"
+									value={password}
+									onChange={(e) => setPassword(e.target.value)}
+									className="w-full px-3 py-2 border border-border rounded-md"
+									required
+									autoComplete="current-password"
+								/>
+							</div>
+							{error && <div className="text-destructive text-sm">{error}</div>}
+							<Button type="submit" className="w-full">
+								Login
+							</Button>
+						</form>
+						<div className="mt-4 border-t border-border pt-4 text-center">
+							<button
+								type="button"
+								onClick={() => {
+									setMode("forgot-password");
+									setError("");
+									setResetError("");
+									setResetMessage("");
+								}}
+								className="text-sm text-muted-foreground hover:text-foreground"
+							>
+								Forgot password?
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						<h1 className="text-2xl font-bold mb-6 text-center">Reset Password</h1>
+						<form onSubmit={handleForgotPassword} className="space-y-4">
 							<div>
 								<label htmlFor="reset-email" className="block text-sm font-medium mb-2">
 									Email
@@ -163,8 +167,22 @@ export function Login(): JSX.Element {
 								Send reset link
 							</Button>
 						</form>
-					)}
-				</div>
+						<div className="mt-4 border-t border-border pt-4 text-center">
+							<button
+								type="button"
+								onClick={() => {
+									setMode("login");
+									setError("");
+									setResetError("");
+									setResetMessage("");
+								}}
+								className="text-sm text-muted-foreground hover:text-foreground"
+							>
+								Back to login
+							</button>
+						</div>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from "../lib/api.js";
 import { Button } from "@/components/ui/button";
 import { queryKeys } from "../lib/query-keys.js";
 import { AuthMeSchema } from "../lib/schemas.js";
+import { useToast } from "../components/ToastProvider";
 
 const FORGOT_PASSWORD_SCHEMA = z.object({
 	success: z.literal(true),
@@ -19,8 +20,7 @@ export function Login(): JSX.Element {
 	const [error, setError] = useState("");
 	const [mode, setMode] = useState<"login" | "forgot-password">("login");
 	const [resetEmail, setResetEmail] = useState("");
-	const [resetMessage, setResetMessage] = useState("");
-	const [resetError, setResetError] = useState("");
+	const { addToast } = useToast();
 	const navigate = useNavigate();
 
 	const { data: authData, isLoading } = useQuery({
@@ -57,22 +57,17 @@ export function Login(): JSX.Element {
 
 	const handleForgotPassword = async (e: FormEvent): Promise<void> => {
 		e.preventDefault();
-		setResetError("");
-		setResetMessage("");
 
 		try {
-			const result = await apiFetch("/auth/forgot-password", FORGOT_PASSWORD_SCHEMA, {
+			await apiFetch("/auth/forgot-password", FORGOT_PASSWORD_SCHEMA, {
 				method: "POST",
 				body: JSON.stringify({ email: resetEmail }),
 			});
-			if (result.resetUrl) {
-				setResetMessage(`Reset link: ${result.resetUrl}`);
-			} else {
-				setResetMessage("If the email exists, a reset link has been created.");
-			}
+			addToast("success", "If the email exists, a password reset link has been sent.");
+			setMode("login");
 		} catch (err: unknown) {
 			const error = err as { message?: string };
-			setResetError(error.message ?? "Failed to request reset");
+			addToast("error", error.message ?? "Failed to request reset");
 		}
 	};
 
@@ -134,8 +129,6 @@ export function Login(): JSX.Element {
 								onClick={() => {
 									setMode("forgot-password");
 									setError("");
-									setResetError("");
-									setResetMessage("");
 								}}
 								className="text-sm text-muted-foreground hover:text-foreground"
 							>
@@ -161,8 +154,6 @@ export function Login(): JSX.Element {
 									autoComplete="email"
 								/>
 							</div>
-							{resetError && <div className="text-destructive text-sm">{resetError}</div>}
-							{resetMessage && <div className="text-sm text-foreground">{resetMessage}</div>}
 							<Button type="submit" variant="secondary" className="w-full">
 								Send reset link
 							</Button>
@@ -173,8 +164,6 @@ export function Login(): JSX.Element {
 								onClick={() => {
 									setMode("login");
 									setError("");
-									setResetError("");
-									setResetMessage("");
 								}}
 								className="text-sm text-muted-foreground hover:text-foreground"
 							>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent, type JSX } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
@@ -7,13 +7,13 @@ import { Button } from "@/components/ui/button";
 import { queryKeys } from "../lib/query-keys.js";
 import { AuthMeSchema } from "../lib/schemas.js";
 
-const ForgotPasswordSchema = z.object({
+const FORGOT_PASSWORD_SCHEMA = z.object({
 	success: z.literal(true),
 	resetToken: z.string().optional(),
 	resetUrl: z.string().optional(),
 });
 
-export function Login() {
+export function Login(): JSX.Element {
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
@@ -55,13 +55,13 @@ export function Login() {
 		}
 	};
 
-	const handleForgotPassword = async (e: FormEvent) => {
+	const handleForgotPassword = async (e: FormEvent): Promise<void> => {
 		e.preventDefault();
 		setResetError("");
 		setResetMessage("");
 
 		try {
-			const result = await apiFetch("/auth/forgot-password", ForgotPasswordSchema, {
+			const result = await apiFetch("/auth/forgot-password", FORGOT_PASSWORD_SCHEMA, {
 				method: "POST",
 				body: JSON.stringify({ email: resetEmail }),
 			});
@@ -70,8 +70,9 @@ export function Login() {
 			} else {
 				setResetMessage("If the email exists, a reset link has been created.");
 			}
-		} catch (err) {
-			setResetError(err instanceof Error ? err.message : "Failed to request reset");
+		} catch (err: unknown) {
+			const error = err as { message?: string };
+			setResetError(error.message ?? "Failed to request reset");
 		}
 	};
 
@@ -129,13 +130,19 @@ export function Login() {
 					<button
 						type="button"
 						onClick={() => setForgotPasswordOpen((current) => !current)}
+						aria-expanded={forgotPasswordOpen}
+						aria-controls="forgot-password-form"
 						className="text-sm text-muted-foreground hover:text-foreground"
 					>
 						{forgotPasswordOpen ? "Hide password reset" : "Forgot password?"}
 					</button>
 
 					{forgotPasswordOpen && (
-						<form onSubmit={handleForgotPassword} className="mt-4 space-y-3">
+						<form
+							id="forgot-password-form"
+							onSubmit={handleForgotPassword}
+							className="mt-4 space-y-3"
+						>
 							<div>
 								<label htmlFor="reset-email" className="block text-sm font-medium mb-2">
 									Email

--- a/client/src/pages/ResetPassword.test.tsx
+++ b/client/src/pages/ResetPassword.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ResetPassword } from "./ResetPassword";
+
+vi.mock("../lib/api.js", () => ({
+	apiFetch: vi.fn(),
+}));
+
+const mockToastContext = {
+	addToast: vi.fn(),
+	removeToast: vi.fn(),
+};
+
+vi.mock("../components/ToastProvider", () => ({
+	useToast: () => mockToastContext,
+}));
+
+const createTestQueryClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	});
+
+const renderWithQueryClientAndParams = (initialEntries: string[]) => {
+	const testQueryClient = createTestQueryClient();
+	return render(
+		<QueryClientProvider client={testQueryClient}>
+			<MemoryRouter initialEntries={initialEntries}>
+				<Routes>
+					<Route path="/reset-password" element={<ResetPassword />} />
+					<Route path="/login" element={<div>Mock Login Page</div>} />
+				</Routes>
+			</MemoryRouter>
+		</QueryClientProvider>
+	);
+};
+
+describe("ResetPassword", () => {
+	let apiFetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { apiFetch } = await import("../lib/api.js");
+		apiFetchMock = apiFetch as MockedFunction<typeof apiFetch>;
+	});
+
+	it("should show error if token parameter is missing", async () => {
+		renderWithQueryClientAndParams(["/reset-password"]);
+
+		expect(await screen.findByText("Reset Password")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Missing or invalid password reset token. Please request a new link from the login page."
+			)
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Back to login" })).toBeInTheDocument();
+	});
+
+	it("should render the form with password and confirm fields when token is present", async () => {
+		renderWithQueryClientAndParams(["/reset-password?token=secret-token"]);
+
+		expect(await screen.findByText("Reset Password")).toBeInTheDocument();
+		expect(screen.getByLabelText("New Password")).toBeInTheDocument();
+		expect(screen.getByLabelText("Confirm New Password")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Reset password" })).toBeInTheDocument();
+	});
+
+	it("should display validation error if passwords do not match", async () => {
+		const user = userEvent.setup();
+		renderWithQueryClientAndParams(["/reset-password?token=secret-token"]);
+
+		await user.type(screen.getByLabelText("New Password"), "password123");
+		await user.type(screen.getByLabelText("Confirm New Password"), "different-password");
+		await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+		expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+		expect(apiFetchMock).not.toHaveBeenCalled();
+	});
+
+	it("should submit password reset request and navigate to login on success", async () => {
+		apiFetchMock.mockImplementation((path: string) => {
+			if (path === "/auth/reset-password") {
+				return Promise.resolve({ success: true });
+			}
+			return Promise.reject(new Error("Not found"));
+		});
+
+		const user = userEvent.setup();
+		renderWithQueryClientAndParams(["/reset-password?token=secret-token"]);
+
+		await user.type(screen.getByLabelText("New Password"), "password123");
+		await user.type(screen.getByLabelText("Confirm New Password"), "password123");
+		await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+		await waitFor(() => {
+			expect(apiFetchMock).toHaveBeenCalledWith(
+				"/auth/reset-password",
+				expect.any(Object),
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ token: "secret-token", password: "password123" }),
+				})
+			);
+			expect(mockToastContext.addToast).toHaveBeenCalledWith(
+				"success",
+				expect.stringContaining("successfully")
+			);
+			expect(screen.getByText("Mock Login Page")).toBeInTheDocument();
+		});
+	});
+
+	it("should display error toast on failed reset request", async () => {
+		apiFetchMock.mockImplementation((path: string) => {
+			if (path === "/auth/reset-password") {
+				return Promise.reject(new Error("Token has expired"));
+			}
+			return Promise.reject(new Error("Not found"));
+		});
+
+		const user = userEvent.setup();
+		renderWithQueryClientAndParams(["/reset-password?token=expired-token"]);
+
+		await user.type(screen.getByLabelText("New Password"), "password123");
+		await user.type(screen.getByLabelText("Confirm New Password"), "password123");
+		await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+		await waitFor(() => {
+			expect(mockToastContext.addToast).toHaveBeenCalledWith("error", "Token has expired");
+			expect(screen.getByText("Token has expired")).toBeInTheDocument();
+		});
+	});
+});

--- a/client/src/pages/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword.tsx
@@ -1,0 +1,116 @@
+import { useState, type FormEvent, type JSX } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { z } from "zod";
+import { apiFetch } from "../lib/api.js";
+import { Button } from "@/components/ui/button";
+import { useToast } from "../components/ToastProvider";
+
+export function ResetPassword(): JSX.Element {
+	const [password, setPassword] = useState("");
+	const [confirmPassword, setConfirmPassword] = useState("");
+	const [error, setError] = useState("");
+	const [isPending, setIsPending] = useState(false);
+	const [searchParams] = useSearchParams();
+	const { addToast } = useToast();
+	const navigate = useNavigate();
+
+	const token = searchParams.get("token") || "";
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError("");
+
+		if (!token) {
+			setError("Missing password reset token. Please request a new reset link.");
+			return;
+		}
+
+		if (password !== confirmPassword) {
+			setError("Passwords do not match");
+			return;
+		}
+
+		setIsPending(true);
+		try {
+			await apiFetch("/auth/reset-password", z.object({ success: z.literal(true) }), {
+				method: "POST",
+				body: JSON.stringify({ token, password }),
+			});
+			addToast("success", "Password has been reset successfully. You can now login.");
+			navigate("/login");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to reset password";
+			setError(message);
+			addToast("error", message);
+		} finally {
+			setIsPending(false);
+		}
+	};
+
+	return (
+		<div className="min-h-screen flex items-center justify-center bg-background px-4">
+			<div className="bg-card p-8 rounded-lg border border-border w-full max-w-sm">
+				<div className="flex justify-center mb-4">
+					<img src="/logo.svg" alt="Docklight logo" className="h-12 w-12" />
+				</div>
+				<h1 className="text-2xl font-bold mb-6 text-center">Reset Password</h1>
+
+				{!token ? (
+					<div className="space-y-4">
+						<div className="text-destructive text-sm text-center">
+							Missing or invalid password reset token. Please request a new link from the login
+							page.
+						</div>
+						<Button onClick={() => navigate("/login")} className="w-full">
+							Back to login
+						</Button>
+					</div>
+				) : (
+					<form onSubmit={handleSubmit} className="space-y-4">
+						<div>
+							<label htmlFor="password" className="block text-sm font-medium mb-2">
+								New Password
+							</label>
+							<input
+								id="password"
+								type="password"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								className="w-full px-3 py-2 border border-border rounded-md"
+								required
+								autoComplete="new-password"
+							/>
+						</div>
+						<div>
+							<label htmlFor="confirm-password" className="block text-sm font-medium mb-2">
+								Confirm New Password
+							</label>
+							<input
+								id="confirm-password"
+								type="password"
+								value={confirmPassword}
+								onChange={(e) => setConfirmPassword(e.target.value)}
+								className="w-full px-3 py-2 border border-border rounded-md"
+								required
+								autoComplete="new-password"
+							/>
+						</div>
+						{error && <div className="text-destructive text-sm">{error}</div>}
+						<Button type="submit" className="w-full" disabled={isPending}>
+							{isPending ? "Resetting…" : "Reset password"}
+						</Button>
+						<div className="mt-4 border-t border-border pt-4 text-center">
+							<button
+								type="button"
+								onClick={() => navigate("/login")}
+								className="text-sm text-muted-foreground hover:text-foreground"
+							>
+								Back to login
+							</button>
+						</div>
+					</form>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -35,6 +35,7 @@ export function Users() {
 
 	// Create form state
 	const [newUsername, setNewUsername] = useState("");
+	const [newEmail, setNewEmail] = useState("");
 	const [newPassword, setNewPassword] = useState("");
 	const [newRole, setNewRole] = useState<UserRole>("viewer");
 	const [createError, setCreateError] = useState("");
@@ -42,11 +43,17 @@ export function Users() {
 	// Edit state
 	const [editId, setEditId] = useState<number | null>(null);
 	const [editRole, setEditRole] = useState<UserRole>("viewer");
+	const [editEmail, setEditEmail] = useState("");
 	const [editPassword, setEditPassword] = useState("");
 	const [editError, setEditError] = useState("");
 
 	const createUserMutation = useMutation({
-		mutationFn: async (userData: { username: string; password: string; role: UserRole }) => {
+		mutationFn: async (userData: {
+			username: string;
+			email?: string;
+			password: string;
+			role: UserRole;
+		}) => {
 			return apiFetch("/users", UserSchema, {
 				method: "POST",
 				body: JSON.stringify(userData),
@@ -55,6 +62,7 @@ export function Users() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.users });
 			setNewUsername("");
+			setNewEmail("");
 			setNewPassword("");
 			setNewRole("viewer");
 			setCreateError("");
@@ -70,7 +78,7 @@ export function Users() {
 			data,
 		}: {
 			id: number;
-			data: { role?: UserRole; password?: string };
+			data: { role?: UserRole; password?: string; email?: string };
 		}) => {
 			return apiFetch(`/users/${id}`, UserSchema, {
 				method: "PUT",
@@ -104,6 +112,7 @@ export function Users() {
 		setCreateError("");
 		createUserMutation.mutate({
 			username: newUsername,
+			email: newEmail || undefined,
 			password: newPassword,
 			role: newRole,
 		});
@@ -111,7 +120,9 @@ export function Users() {
 
 	const handleEditSave = async (id: number) => {
 		setEditError("");
-		const body: { role?: UserRole; password?: string } = { role: editRole };
+		const body: { role?: UserRole; password?: string; email?: string } = { role: editRole };
+		if (editEmail.trim()) body.email = editEmail.trim();
+		if (!editEmail.trim() && editId !== null) body.email = "";
 		if (editPassword) body.password = editPassword;
 		updateUserMutation.mutate({ id, data: body });
 	};
@@ -124,6 +135,7 @@ export function Users() {
 	const startEdit = (user: User) => {
 		setEditId(user.id);
 		setEditRole(user.role);
+		setEditEmail(user.email ?? "");
 		setEditPassword("");
 		setEditError("");
 	};
@@ -139,7 +151,7 @@ export function Users() {
 			<div className="bg-card rounded-lg border border-border p-6 mb-6">
 				<h2 className="text-lg font-semibold mb-4">Add User</h2>
 				<form onSubmit={handleCreate} className="flex flex-col gap-3">
-					<div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+					<div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
 						<div>
 							<label htmlFor="new-username" className="block text-sm font-medium mb-1">
 								Username
@@ -152,6 +164,20 @@ export function Users() {
 								className="w-full px-3 py-2 border border-border rounded-md text-sm"
 								required
 								autoComplete="off"
+							/>
+						</div>
+						<div>
+							<label htmlFor="new-email" className="block text-sm font-medium mb-1">
+								Email
+							</label>
+							<input
+								id="new-email"
+								type="email"
+								value={newEmail}
+								onChange={(e) => setNewEmail(e.target.value)}
+								className="w-full px-3 py-2 border border-border rounded-md text-sm"
+								autoComplete="email"
+								placeholder="you@example.com"
 							/>
 						</div>
 						<div>
@@ -210,6 +236,7 @@ export function Users() {
 							<thead className="bg-muted/50 text-left">
 								<tr>
 									<th className="px-6 py-3 font-medium text-muted-foreground">Username</th>
+									<th className="px-6 py-3 font-medium text-muted-foreground">Email</th>
 									<th className="px-6 py-3 font-medium text-muted-foreground">Role</th>
 									<th className="px-6 py-3 font-medium text-muted-foreground hidden sm:table-cell">
 										Created
@@ -221,6 +248,20 @@ export function Users() {
 								{userList.map((user) => (
 									<tr key={user.id}>
 										<td className="px-6 py-3 font-medium">{user.username}</td>
+										<td className="px-6 py-3 whitespace-nowrap">
+											{editId === user.id ? (
+												<input
+													type="email"
+													value={editEmail}
+													onChange={(e) => setEditEmail(e.target.value)}
+													className="border border-border rounded-md px-2 py-1 text-xs w-56 max-w-full"
+													placeholder="you@example.com"
+													autoComplete="email"
+												/>
+											) : (
+												user.email ?? <span className="text-muted-foreground/60">—</span>
+											)}
+										</td>
 										<td className="px-6 py-3 whitespace-nowrap">
 											{editId === user.id ? (
 												<select
@@ -292,7 +333,7 @@ export function Users() {
 								))}
 								{userList.length === 0 && (
 									<tr>
-										<td colSpan={4} className="px-6 py-4 text-center text-muted-foreground/60">
+										<td colSpan={5} className="px-6 py-4 text-center text-muted-foreground/60">
 											No users yet
 										</td>
 									</tr>

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -259,7 +259,7 @@ export function Users() {
 													autoComplete="email"
 												/>
 											) : (
-												user.email ?? <span className="text-muted-foreground/60">—</span>
+												(user.email ?? <span className="text-muted-foreground/60">—</span>)
 											)}
 										</td>
 										<td className="px-6 py-3 whitespace-nowrap">

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -6,7 +6,7 @@ How to back up and restore Docklight configuration (users and settings).
 
 The backup includes:
 
-- **Users** — all accounts with their usernames, hashed passwords, roles, and creation timestamps
+- **Users** — all accounts with their usernames, emails (optional), hashed passwords, roles, and creation timestamps
 - **Environment configuration reference** — which env vars are set (values are **not** exported)
 
 > **Note:** The SQLite command history and audit log are not included in the backup. Only the configuration needed to restore access and user accounts is exported.
@@ -23,15 +23,16 @@ curl -s -b "session=<your-session-token>" \
   -o docklight-backup-$(date +%F).json
 ```
 
-The downloaded file looks like:
+The downloaded file looks like (version 1.1):
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "timestamp": "2024-01-15T10:30:00.000Z",
   "users": [
     {
       "username": "admin",
+      "email": "admin@example.com",
       "password_hash": "abc123:...",
       "role": "admin",
       "createdAt": "2024-01-01T00:00:00.000Z"
@@ -72,7 +73,8 @@ A successful response:
 
 ### Restore behaviour
 
-- Users in the backup are **upserted** — existing accounts with the same username are updated; accounts not present in the backup are left untouched.
+- Supports both version `1.0` (legacy format without email) and version `1.1` (current format with email support).
+- Users in the backup are **upserted** — existing accounts with the same username are updated (including their emails); accounts not present in the backup are left untouched.
 - The backup must contain at least one `admin` role user; restores without an admin are rejected to prevent lockout.
 - `createdAt` timestamps are preserved from the backup.
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import express, { type Express, type Request, type Response, type NextFunction } from "express";
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
 import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./lib/apps.js", () => ({
 	getApps: vi.fn(),
@@ -67,18 +67,18 @@ vi.mock("./lib/websocket.js", () => ({
 	setupLogStreaming: vi.fn(),
 }));
 
-import { getApps, getAppDetail, restartApp, rebuildApp, scaleApp } from "./lib/apps.js";
-import { authMiddleware, setAuthCookie, clearAuthCookie, login } from "./lib/auth.js";
+import { getAppDetail, getApps, rebuildApp, restartApp, scaleApp } from "./lib/apps.js";
+import { authMiddleware, clearAuthCookie, login, setAuthCookie } from "./lib/auth.js";
 import { getConfig, setConfig, unsetConfig } from "./lib/config.js";
 import {
-	getDatabases,
 	createDatabase,
 	destroyDatabase,
+	getDatabases,
 	linkDatabase,
 	unlinkDatabase,
 } from "./lib/databases.js";
 import { getRecentCommands } from "./lib/db.js";
-import { getDomains, addDomain, removeDomain } from "./lib/domains.js";
+import { addDomain, getDomains, removeDomain } from "./lib/domains.js";
 import { getPlugins } from "./lib/plugins.js";
 import { getServerHealth } from "./lib/server.js";
 import { enableSSL, getSSL, renewSSL } from "./lib/ssl.js";
@@ -368,7 +368,7 @@ describe("API Routes", () => {
 
 	describe("POST /api/auth/login", () => {
 		it("should return success on valid credentials", async () => {
-			const mockUser = { id: 1, username: "testuser", role: "admin" as const };
+			const mockUser = { id: 1, username: "testuser", role: "admin" as const, sessionVersion: 0 };
 			vi.mocked(login).mockResolvedValue(mockUser);
 
 			const response = await request(app)

--- a/server/lib/auth.test.ts
+++ b/server/lib/auth.test.ts
@@ -4,6 +4,7 @@ import type { Request, Response, NextFunction } from "express";
 // Mock db and logger before importing auth
 vi.mock("./db.js", () => ({
 	getUserByUsername: vi.fn(),
+	getUserByEmail: vi.fn(),
 }));
 
 vi.mock("./logger.js", () => ({
@@ -60,6 +61,7 @@ describe("login", () => {
 		vi.mocked(getUserByUsername).mockReturnValue({
 			id: 1,
 			username: "alice",
+			email: null,
 			password_hash: hash,
 			role: "admin",
 			createdAt: new Date().toISOString(),
@@ -73,6 +75,7 @@ describe("login", () => {
 		vi.mocked(getUserByUsername).mockReturnValue({
 			id: 1,
 			username: "alice",
+			email: null,
 			password_hash: hash,
 			role: "admin",
 			createdAt: new Date().toISOString(),

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,10 +1,10 @@
 import { randomBytes, scrypt, timingSafeEqual, createHash } from "crypto";
-import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { promisify } from "util";
-import type { UserRole } from "./db.js";
 import { getUserByUsername, getUserByEmail } from "./db.js";
 import { logger } from "./logger.js";
+import type { NextFunction, Request, Response } from "express";
+import type { UserRole } from "./db.js";
 
 const scryptAsync = promisify(scrypt);
 
@@ -85,12 +85,11 @@ export function hashResetToken(token: string): string {
 	return createHash("sha256").update(token).digest("hex");
 }
 
-/** Login: validates username + password against the users table. */
 export async function login(
 	username: string,
 	password: string
 ): Promise<{ id: number; username: string; role: UserRole } | null> {
-	const user = getUserByUsername(username) ?? getUserByEmail(username);
+	const user = getUserByUsername(username) ?? getUserByEmail(username.trim().toLowerCase());
 	if (!user) return null;
 
 	const valid = await verifyPassword(password, user.password_hash);

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,9 +1,9 @@
-import { randomBytes, scrypt, timingSafeEqual } from "crypto";
+import { randomBytes, scrypt, timingSafeEqual, createHash } from "crypto";
 import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { promisify } from "util";
 import type { UserRole } from "./db.js";
-import { getUserByUsername } from "./db.js";
+import { getUserByUsername, getUserByEmail } from "./db.js";
 import { logger } from "./logger.js";
 
 const scryptAsync = promisify(scrypt);
@@ -81,12 +81,16 @@ export function verifyToken(token: string): JWTPayload | null {
 	}
 }
 
+export function hashResetToken(token: string): string {
+	return createHash("sha256").update(token).digest("hex");
+}
+
 /** Login: validates username + password against the users table. */
 export async function login(
 	username: string,
 	password: string
 ): Promise<{ id: number; username: string; role: UserRole } | null> {
-	const user = getUserByUsername(username);
+	const user = getUserByUsername(username) ?? getUserByEmail(username);
 	if (!user) return null;
 
 	const valid = await verifyPassword(password, user.password_hash);
@@ -121,7 +125,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction) 
 	}
 
 	const payload = verifyToken(token);
-	if (!payload || !payload.authenticated) {
+	if (!payload?.authenticated) {
 		res.status(401).json({ error: "Unauthorized" });
 		return;
 	}

--- a/server/lib/db.test.ts
+++ b/server/lib/db.test.ts
@@ -250,6 +250,7 @@ describe("importBackup validation", () => {
 		users: [
 			{
 				username: "admin",
+				email: null,
 				password_hash: "salt:hash",
 				role: "admin",
 				createdAt: "2024-01-01T00:00:00.000Z",
@@ -282,7 +283,7 @@ describe("importBackup validation", () => {
 	it("should reject user with missing username", () => {
 		const result = importBackup({
 			...validBackup,
-			users: [{ username: "", password_hash: "hash", role: "admin", createdAt: "" }],
+			users: [{ username: "", email: null, password_hash: "hash", role: "admin", createdAt: "" }],
 		});
 		expect(result.success).toBe(false);
 		expect(result.error).toContain("username");
@@ -291,7 +292,7 @@ describe("importBackup validation", () => {
 	it("should reject user with missing password_hash", () => {
 		const result = importBackup({
 			...validBackup,
-			users: [{ username: "admin", password_hash: "", role: "admin", createdAt: "" }],
+			users: [{ username: "admin", email: null, password_hash: "", role: "admin", createdAt: "" }],
 		});
 		expect(result.success).toBe(false);
 		expect(result.error).toContain("password_hash");
@@ -303,6 +304,7 @@ describe("importBackup validation", () => {
 			users: [
 				{
 					username: "admin",
+					email: null,
 					password_hash: "hash",
 					role: "superuser" as "admin",
 					createdAt: "",
@@ -319,6 +321,7 @@ describe("importBackup validation", () => {
 			users: [
 				{
 					username: "user1",
+					email: null,
 					password_hash: "hash",
 					role: "viewer",
 					createdAt: "",

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -60,11 +60,38 @@ function getDb(): Database {
 	  CREATE TABLE IF NOT EXISTS users (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		username TEXT UNIQUE NOT NULL,
+		email TEXT,
 		password_hash TEXT NOT NULL,
 		role TEXT NOT NULL DEFAULT 'viewer',
 		createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
 	  )
 	`);
+
+	const userColumns = newDb.prepare("PRAGMA table_info(users)").all() as { name: string }[];
+	if (!userColumns.some((column) => column.name === "email")) {
+		newDb.exec("ALTER TABLE users ADD COLUMN email TEXT");
+	}
+	newDb.exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email) WHERE email IS NOT NULL AND email != ''"
+	);
+
+	newDb.exec(`
+	  CREATE TABLE IF NOT EXISTS password_reset_tokens (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id INTEGER NOT NULL,
+		token_hash TEXT NOT NULL UNIQUE,
+		expiresAt DATETIME NOT NULL,
+		usedAt DATETIME,
+		createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+		FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+	  )
+	`);
+	newDb.exec(
+		"CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id)"
+	);
+	newDb.exec(
+		"CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expiresAt ON password_reset_tokens(expiresAt)"
+	);
 
 	newDb.exec(`
 	  CREATE TABLE IF NOT EXISTS audit_log (
@@ -228,6 +255,7 @@ export type UserRole = "admin" | "operator" | "viewer";
 export interface User {
 	id: number;
 	username: string;
+	email: string | null;
 	password_hash: string;
 	role: UserRole;
 	createdAt: string;
@@ -236,47 +264,67 @@ export interface User {
 export interface SafeUser {
 	id: number;
 	username: string;
+	email: string | null;
 	role: UserRole;
 	createdAt: string;
 }
 
-export function createUser(username: string, passwordHash: string, role: UserRole): SafeUser {
+export function createUser(
+	username: string,
+	passwordHash: string,
+	role: UserRole,
+	email: string | null = null
+): SafeUser {
 	const stmt = getDb().prepare(
-		"INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)"
+		"INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)"
 	);
-	stmt.run(username, passwordHash, role);
+	stmt.run(username, email, passwordHash, role);
 	const user = getDb()
-		.prepare("SELECT id, username, role, createdAt FROM users WHERE username = ?")
+		.prepare("SELECT id, username, email, role, createdAt FROM users WHERE username = ?")
 		.get(username) as SafeUser;
 	return user;
 }
 
 export function getUserByUsername(username: string): User | null {
 	const stmt = getDb().prepare(
-		"SELECT id, username, password_hash, role, createdAt FROM users WHERE username = ?"
+		"SELECT id, username, email, password_hash, role, createdAt FROM users WHERE username = ?"
 	);
 	return (stmt.get(username) as User) ?? null;
 }
 
+export function getUserByEmail(email: string): User | null {
+	const stmt = getDb().prepare(
+		"SELECT id, username, email, password_hash, role, createdAt FROM users WHERE email = ?"
+	);
+	return (stmt.get(email) as User) ?? null;
+}
+
 export function getUserById(id: number): SafeUser | null {
-	const stmt = getDb().prepare("SELECT id, username, role, createdAt FROM users WHERE id = ?");
+	const stmt = getDb().prepare("SELECT id, username, email, role, createdAt FROM users WHERE id = ?");
 	return (stmt.get(id) as SafeUser) ?? null;
 }
 
 export function getAllUsers(): SafeUser[] {
 	const stmt = getDb().prepare(
-		"SELECT id, username, role, createdAt FROM users ORDER BY createdAt ASC"
+		"SELECT id, username, email, role, createdAt FROM users ORDER BY createdAt ASC"
 	);
 	return stmt.all() as SafeUser[];
 }
 
-export function updateUser(id: number, updates: { role?: UserRole; passwordHash?: string }): void {
+export function updateUser(
+	id: number,
+	updates: { role?: UserRole; passwordHash?: string; email?: string | null }
+): void {
 	const fields: string[] = [];
 	const params: unknown[] = [];
 
 	if (updates.role !== undefined) {
 		fields.push("role = ?");
 		params.push(updates.role);
+	}
+	if (updates.email !== undefined) {
+		fields.push("email = ?");
+		params.push(updates.email);
 	}
 	if (updates.passwordHash !== undefined) {
 		fields.push("password_hash = ?");
@@ -342,6 +390,51 @@ export function deleteUserWithAdminGuard(id: number): {
 	db.prepare("DELETE FROM users WHERE id = ?").run(id);
 
 	return { success: true };
+}
+
+export interface PasswordResetToken {
+	id: number;
+	userId: number;
+	tokenHash: string;
+	expiresAt: string;
+	usedAt: string | null;
+	createdAt: string;
+}
+
+export function createPasswordResetToken(
+	userId: number,
+	tokenHash: string,
+	expiresAt: string
+): PasswordResetToken {
+	const stmt = getDb().prepare(
+		"INSERT INTO password_reset_tokens (user_id, token_hash, expiresAt) VALUES (?, ?, ?)"
+	);
+	stmt.run(userId, tokenHash, expiresAt);
+	return getDb()
+		.prepare(
+			"SELECT id, user_id as userId, token_hash as tokenHash, expiresAt, usedAt, createdAt FROM password_reset_tokens WHERE token_hash = ?"
+		)
+		.get(tokenHash) as PasswordResetToken;
+}
+
+export function getPasswordResetTokenByHash(tokenHash: string): PasswordResetToken | null {
+	const stmt = getDb().prepare(
+		"SELECT id, user_id as userId, token_hash as tokenHash, expiresAt, usedAt, createdAt FROM password_reset_tokens WHERE token_hash = ?"
+	);
+	return (stmt.get(tokenHash) as PasswordResetToken) ?? null;
+}
+
+export function markPasswordResetTokenUsed(tokenHash: string): void {
+	getDb()
+		.prepare("UPDATE password_reset_tokens SET usedAt = CURRENT_TIMESTAMP WHERE token_hash = ?")
+		.run(tokenHash);
+}
+
+export function deleteExpiredPasswordResetTokens(): number {
+	const result = getDb()
+		.prepare("DELETE FROM password_reset_tokens WHERE datetime(expiresAt) <= datetime('now')")
+		.run() as unknown as { changes: number };
+	return result.changes;
 }
 
 export function deleteUser(id: number): void {
@@ -412,6 +505,7 @@ export function insertAuditLog(
 
 export interface BackupUser {
 	username: string;
+	email: string | null;
 	password_hash: string;
 	role: UserRole;
 	createdAt: string;
@@ -435,7 +529,7 @@ const ENV_VARS_TO_REFERENCE = [
 
 export function exportBackup(): BackupData {
 	const users = getDb()
-		.prepare("SELECT username, password_hash, role, createdAt FROM users ORDER BY id ASC")
+		.prepare("SELECT username, email, password_hash, role, createdAt FROM users ORDER BY id ASC")
 		.all() as BackupUser[];
 
 	const envConfig: Record<string, boolean> = {};
@@ -444,7 +538,7 @@ export function exportBackup(): BackupData {
 	}
 
 	return {
-		version: "1.0",
+		version: "1.1",
 		timestamp: new Date().toISOString(),
 		users,
 		envConfig,
@@ -457,7 +551,7 @@ export function importBackup(backup: BackupData): {
 	success: boolean;
 	error?: string;
 } {
-	if (!backup || backup.version !== "1.0" || !Array.isArray(backup.users)) {
+	if (!backup || (backup.version !== "1.0" && backup.version !== "1.1") || !Array.isArray(backup.users)) {
 		return { success: false, error: "Invalid backup format" };
 	}
 
@@ -466,6 +560,12 @@ export function importBackup(backup: BackupData): {
 			return {
 				success: false,
 				error: "Invalid user: username must be a non-empty string",
+			};
+		}
+		if (user.email !== undefined && user.email !== null && typeof user.email !== "string") {
+			return {
+				success: false,
+				error: "Invalid user: email must be a string or null",
 			};
 		}
 		if (!user.password_hash || typeof user.password_hash !== "string") {
@@ -492,13 +592,13 @@ export function importBackup(backup: BackupData): {
 
 	const db = getDb();
 	const upsert = db.prepare(
-		"INSERT INTO users (username, password_hash, role, createdAt) VALUES (?, ?, ?, ?) ON CONFLICT(username) DO UPDATE SET password_hash = excluded.password_hash, role = excluded.role, createdAt = excluded.createdAt"
+		"INSERT INTO users (username, email, password_hash, role, createdAt) VALUES (?, ?, ?, ?, ?) ON CONFLICT(username) DO UPDATE SET email = excluded.email, password_hash = excluded.password_hash, role = excluded.role, createdAt = excluded.createdAt"
 	);
 
 	try {
 		const transaction = db.transaction((users: BackupUser[]) => {
 			for (const user of users) {
-				upsert.run(user.username, user.password_hash, user.role, user.createdAt);
+				upsert.run(user.username, user.email ?? null, user.password_hash, user.role, user.createdAt);
 			}
 		});
 		transaction(backup.users);

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -14,7 +14,7 @@ type Statement = {
 type Database = {
 	prepare: (sql: string) => Statement;
 	exec: (sql: string) => void;
-	transaction: <T>(fn: (arg: T) => void) => (arg: T) => void;
+	transaction: <T, R = void>(fn: (arg: T) => R) => (arg: T) => R;
 };
 
 interface UserRoleRow {
@@ -38,6 +38,7 @@ function getDb(): Database {
 
 	newDb.pragma("journal_mode = WAL");
 	newDb.pragma("synchronous = NORMAL");
+	newDb.pragma("foreign_keys = ON");
 
 	newDb.exec(`
 	  CREATE TABLE IF NOT EXISTS command_history (
@@ -300,7 +301,9 @@ export function getUserByEmail(email: string): User | null {
 }
 
 export function getUserById(id: number): SafeUser | null {
-	const stmt = getDb().prepare("SELECT id, username, email, role, createdAt FROM users WHERE id = ?");
+	const stmt = getDb().prepare(
+		"SELECT id, username, email, role, createdAt FROM users WHERE id = ?"
+	);
 	return (stmt.get(id) as SafeUser) ?? null;
 }
 
@@ -424,10 +427,28 @@ export function getPasswordResetTokenByHash(tokenHash: string): PasswordResetTok
 	return (stmt.get(tokenHash) as PasswordResetToken) ?? null;
 }
 
-export function markPasswordResetTokenUsed(tokenHash: string): void {
-	getDb()
-		.prepare("UPDATE password_reset_tokens SET usedAt = CURRENT_TIMESTAMP WHERE token_hash = ?")
-		.run(tokenHash);
+export function markPasswordResetTokenUsed(tokenHash: string): boolean {
+	const result = getDb()
+		.prepare(
+			"UPDATE password_reset_tokens SET usedAt = CURRENT_TIMESTAMP WHERE token_hash = ? AND usedAt IS NULL AND datetime(expiresAt) > datetime('now')"
+		)
+		.run(tokenHash) as unknown as { changes: number };
+	return result.changes === 1;
+}
+
+export function resetPasswordWithToken(
+	tokenHash: string,
+	userId: number,
+	passwordHash: string
+): boolean {
+	const db = getDb();
+	const txn = db.transaction((_: null) => {
+		const consumed = markPasswordResetTokenUsed(tokenHash);
+		if (!consumed) return false;
+		updateUser(userId, { passwordHash });
+		return true;
+	});
+	return txn(null);
 }
 
 export function deleteExpiredPasswordResetTokens(): number {
@@ -551,7 +572,11 @@ export function importBackup(backup: BackupData): {
 	success: boolean;
 	error?: string;
 } {
-	if (!backup || (backup.version !== "1.0" && backup.version !== "1.1") || !Array.isArray(backup.users)) {
+	if (
+		!backup ||
+		(backup.version !== "1.0" && backup.version !== "1.1") ||
+		!Array.isArray(backup.users)
+	) {
 		return { success: false, error: "Invalid backup format" };
 	}
 
@@ -598,7 +623,13 @@ export function importBackup(backup: BackupData): {
 	try {
 		const transaction = db.transaction((users: BackupUser[]) => {
 			for (const user of users) {
-				upsert.run(user.username, user.email ?? null, user.password_hash, user.role, user.createdAt);
+				upsert.run(
+					user.username,
+					user.email ?? null,
+					user.password_hash,
+					user.role,
+					user.createdAt
+				);
 			}
 		});
 		transaction(backup.users);

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -341,31 +341,34 @@ export function updateUser(
 	stmt.run(...params);
 }
 
-export function demoteAdminWithGuard(
+export function updateUserWithGuard(
 	id: number,
-	newRole: UserRole
+	updates: { role?: UserRole; passwordHash?: string; email?: string | null }
 ): { success: boolean; error?: string } {
 	const db = getDb();
+	const txn = db.transaction((_: null) => {
+		const existing = db.prepare("SELECT role FROM users WHERE id = ?").get(id) as
+			| UserRoleRow
+			| undefined;
 
-	const adminBefore = db
-		.prepare("SELECT COUNT(*) as count FROM users WHERE role = 'admin'")
-		.get() as { count: number };
+		if (!existing) {
+			return { success: false, error: "User not found" };
+		}
 
-	if (adminBefore.count <= 1) {
-		return { success: false, error: "Cannot demote the last admin user" };
-	}
+		if (updates.role !== undefined && existing.role === "admin" && updates.role !== "admin") {
+			const adminCount = db
+				.prepare("SELECT COUNT(*) as count FROM users WHERE role = 'admin'")
+				.get() as { count: number };
 
-	db.prepare("UPDATE users SET role = ? WHERE id = ? AND role = 'admin'").run(newRole, id);
+			if (adminCount.count <= 1) {
+				return { success: false, error: "Cannot demote the last admin user" };
+			}
+		}
 
-	const adminAfter = db
-		.prepare("SELECT COUNT(*) as count FROM users WHERE role = 'admin'")
-		.get() as { count: number };
-
-	if (adminAfter.count >= adminBefore.count) {
-		return { success: false, error: "Cannot demote the last admin user" };
-	}
-
-	return { success: true };
+		updateUser(id, updates);
+		return { success: true };
+	});
+	return txn(null);
 }
 
 export function deleteUserWithAdminGuard(id: number): {
@@ -620,13 +623,11 @@ export function importBackup(backup: BackupData): {
 	try {
 		const transaction = db.transaction((users: BackupUser[]) => {
 			for (const user of users) {
-				upsert.run(
-					user.username,
-					user.email ?? null,
-					user.password_hash,
-					user.role,
-					user.createdAt
-				);
+				const normalizedEmail =
+					typeof user.email === "string" && user.email.trim().length > 0
+						? user.email.trim().toLowerCase()
+						: null;
+				upsert.run(user.username, normalizedEmail, user.password_hash, user.role, user.createdAt);
 			}
 		});
 		transaction(backup.users);

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -346,7 +346,7 @@ export function updateUserWithGuard(
 	updates: { role?: UserRole; passwordHash?: string; email?: string | null }
 ): { success: boolean; error?: string } {
 	const db = getDb();
-	const txn = db.transaction((_: null) => {
+	const txn = db.transaction((_: null): { success: boolean; error?: string } => {
 		const existing = db.prepare("SELECT role FROM users WHERE id = ?").get(id) as
 			| UserRoleRow
 			| undefined;
@@ -526,7 +526,7 @@ export function insertAuditLog(
 
 export interface BackupUser {
 	username: string;
-	email: string | null;
+	email?: string | null;
 	password_hash: string;
 	role: UserRole;
 	createdAt: string;
@@ -619,9 +619,13 @@ export function importBackup(backup: BackupData): {
 	const upsert = db.prepare(
 		"INSERT INTO users (username, email, password_hash, role, createdAt) VALUES (?, ?, ?, ?, ?) ON CONFLICT(username) DO UPDATE SET email = excluded.email, password_hash = excluded.password_hash, role = excluded.role, createdAt = excluded.createdAt"
 	);
+	const clearEmail = db.prepare("UPDATE users SET email = NULL WHERE username = ?");
 
 	try {
-		const transaction = db.transaction((users: BackupUser[]) => {
+		const transaction = db.transaction((users: BackupUser[]): void => {
+			for (const user of users) {
+				clearEmail.run(user.username);
+			}
 			for (const user of users) {
 				const normalizedEmail =
 					typeof user.email === "string" && user.email.trim().length > 0

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -420,33 +420,30 @@ export function createPasswordResetToken(
 		.get(tokenHash) as PasswordResetToken;
 }
 
-export function getPasswordResetTokenByHash(tokenHash: string): PasswordResetToken | null {
-	const stmt = getDb().prepare(
-		"SELECT id, user_id as userId, token_hash as tokenHash, expiresAt, usedAt, createdAt FROM password_reset_tokens WHERE token_hash = ?"
-	);
-	return (stmt.get(tokenHash) as PasswordResetToken) ?? null;
-}
-
-export function markPasswordResetTokenUsed(tokenHash: string): boolean {
-	const result = getDb()
-		.prepare(
-			"UPDATE password_reset_tokens SET usedAt = CURRENT_TIMESTAMP WHERE token_hash = ? AND usedAt IS NULL AND datetime(expiresAt) > datetime('now')"
-		)
-		.run(tokenHash) as unknown as { changes: number };
-	return result.changes === 1;
-}
-
-export function resetPasswordWithToken(
-	tokenHash: string,
-	userId: number,
-	passwordHash: string
-): boolean {
+export function resetPasswordWithToken(tokenHash: string, passwordHash: string): number | null {
 	const db = getDb();
 	const txn = db.transaction((_: null) => {
-		const consumed = markPasswordResetTokenUsed(tokenHash);
-		if (!consumed) return false;
-		updateUser(userId, { passwordHash });
-		return true;
+		const token = db
+			.prepare(
+				"SELECT user_id as userId, expiresAt, usedAt FROM password_reset_tokens WHERE token_hash = ?"
+			)
+			.get(tokenHash) as { userId: number; expiresAt: string; usedAt: string | null } | undefined;
+
+		if (!token || token.usedAt !== null || new Date(token.expiresAt).getTime() <= Date.now()) {
+			return null;
+		}
+
+		const result = db
+			.prepare(
+				"UPDATE password_reset_tokens SET usedAt = CURRENT_TIMESTAMP WHERE token_hash = ? AND usedAt IS NULL"
+			)
+			.run(tokenHash) as unknown as { changes: number };
+		if (result.changes !== 1) {
+			return null;
+		}
+
+		updateUser(token.userId, { passwordHash });
+		return token.userId;
 	});
 	return txn(null);
 }

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -1,0 +1,14 @@
+import { logger } from "./logger.js";
+
+export function buildPasswordResetUrl(token: string): string {
+	const appUrl = process.env.DOCKLIGHT_APP_URL || "";
+	return `${appUrl}/reset-password?token=${token}`;
+}
+
+export async function sendPasswordResetEmail(opts: {
+	to: string;
+	username: string;
+	resetUrl: string;
+}): Promise<void> {
+	logger.info({ to: opts.to, username: opts.username }, "Password reset email requested");
+}

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -10,5 +10,37 @@ export async function sendPasswordResetEmail(opts: {
 	username: string;
 	resetUrl: string;
 }): Promise<void> {
-	logger.info({ to: opts.to, username: opts.username }, "Password reset email requested");
+	const apiKey = process.env.RESEND_API_KEY;
+	const from = process.env.RESEND_FROM_EMAIL;
+
+	if (!apiKey || !from) {
+		logger.warn(
+			"Resend email service is not configured (missing RESEND_API_KEY or RESEND_FROM_EMAIL)"
+		);
+		return;
+	}
+
+	logger.info("Sending password reset email");
+
+	const res = await fetch("https://api.resend.com/emails", {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			from,
+			to: opts.to,
+			subject: "Reset your Docklight password",
+			html: `<p>Hello ${opts.username},</p>
+<p>You requested to reset your password for Docklight. Click the link below to proceed:</p>
+<p><a href="${opts.resetUrl}">${opts.resetUrl}</a></p>
+<p>If you did not request this, you can safely ignore this email.</p>`,
+		}),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`Failed to send password reset email: ${text}`);
+	}
 }

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -5,6 +5,15 @@ export function buildPasswordResetUrl(token: string): string {
 	return `${appUrl}/reset-password?token=${token}`;
 }
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}
+
 export async function sendPasswordResetEmail(opts: {
 	to: string;
 	username: string;
@@ -22,25 +31,33 @@ export async function sendPasswordResetEmail(opts: {
 
 	logger.info("Sending password reset email");
 
-	const res = await fetch("https://api.resend.com/emails", {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			from,
-			to: opts.to,
-			subject: "Reset your Docklight password",
-			html: `<p>Hello ${opts.username},</p>
-<p>You requested to reset your password for Docklight. Click the link below to proceed:</p>
-<p><a href="${opts.resetUrl}">${opts.resetUrl}</a></p>
-<p>If you did not request this, you can safely ignore this email.</p>`,
-		}),
-	});
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`Failed to send password reset email: ${text}`);
+	try {
+		const res = await fetch("https://api.resend.com/emails", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			signal: controller.signal,
+			body: JSON.stringify({
+				from,
+				to: opts.to,
+				subject: "Reset your Docklight password",
+				html: `<p>Hello ${escapeHtml(opts.username)},</p>
+<p>You requested to reset your password for Docklight. Click the link below to proceed:</p>
+<p><a href="${escapeHtml(opts.resetUrl)}">${escapeHtml(opts.resetUrl)}</a></p>
+<p>If you did not request this, you can safely ignore this email.</p>`,
+			}),
+		});
+
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Failed to send password reset email: ${text}`);
+		}
+	} finally {
+		clearTimeout(timeoutId);
 	}
 }

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -1,0 +1,162 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/rate-limiter.js", () => ({
+	authRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+	authCheckRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("../lib/db.js", () => ({
+	getUserByUsername: vi.fn(),
+	getUserByEmail: vi.fn(),
+	getUserAuthStateById: vi.fn(),
+	createPasswordResetToken: vi.fn(),
+	getPasswordResetTokenByHash: vi.fn(),
+	markPasswordResetTokenUsed: vi.fn(),
+	updateUser: vi.fn(),
+}));
+
+vi.mock("../lib/email.js", () => ({
+	buildPasswordResetUrl: vi.fn(
+		(token: string) => `https://docklight.example.com/reset-password?token=${token}`
+	),
+	sendPasswordResetEmail: vi.fn(),
+}));
+
+vi.mock("./util.js", () => ({
+	safeAuditLogWithUserId: vi.fn(),
+}));
+
+import { hashResetToken } from "../lib/auth.js";
+import {
+	createPasswordResetToken,
+	getPasswordResetTokenByHash,
+	getUserByEmail,
+	markPasswordResetTokenUsed,
+	updateUser,
+} from "../lib/db.js";
+import { sendPasswordResetEmail } from "../lib/email.js";
+import { registerAuthRoutes } from "./auth.js";
+
+function createTestApp(): express.Express {
+	const app = express();
+	app.use(express.json());
+	registerAuthRoutes(app);
+	return app;
+}
+
+describe("auth routes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("NODE_ENV", "test");
+		vi.stubEnv("RESEND_API_KEY", "");
+		vi.stubEnv("RESEND_FROM_EMAIL", "");
+		vi.stubEnv("DOCKLIGHT_APP_URL", "https://docklight.example.com");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("should return reset url in non-production when resend is not configured", async () => {
+		vi.mocked(getUserByEmail).mockReturnValue({
+			id: 1,
+			username: "alice",
+			email: "alice@example.com",
+			password_hash: "hash",
+			role: "admin",
+			sessionVersion: 0,
+			createdAt: new Date().toISOString(),
+		});
+		vi.mocked(createPasswordResetToken).mockReturnValue({
+			id: 1,
+			userId: 1,
+			tokenHash: "token-hash",
+			expiresAt: new Date(Date.now() + 1000 * 60 * 30).toISOString(),
+			usedAt: null,
+			createdAt: new Date().toISOString(),
+		});
+
+		const response = await request(createTestApp())
+			.post("/api/auth/forgot-password")
+			.send({ email: "alice@example.com" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toHaveProperty("success", true);
+		expect(response.body).toHaveProperty("resetToken");
+		expect(response.body).toHaveProperty(
+			"resetUrl",
+			`https://docklight.example.com/reset-password?token=${response.body.resetToken}`
+		);
+		expect(sendPasswordResetEmail).not.toHaveBeenCalled();
+		expect(createPasswordResetToken).toHaveBeenCalledOnce();
+	});
+
+	it("should send reset email through resend when configured", async () => {
+		vi.stubEnv("RESEND_API_KEY", "re_123");
+		vi.stubEnv("RESEND_FROM_EMAIL", "Docklight <no-reply@docklight.example.com>");
+		vi.mocked(getUserByEmail).mockReturnValue({
+			id: 1,
+			username: "alice",
+			email: "alice@example.com",
+			password_hash: "hash",
+			role: "admin",
+			sessionVersion: 0,
+			createdAt: new Date().toISOString(),
+		});
+		vi.mocked(createPasswordResetToken).mockReturnValue({
+			id: 1,
+			userId: 1,
+			tokenHash: "token-hash",
+			expiresAt: new Date(Date.now() + 1000 * 60 * 30).toISOString(),
+			usedAt: null,
+			createdAt: new Date().toISOString(),
+		});
+
+		const response = await request(createTestApp())
+			.post("/api/auth/forgot-password")
+			.send({ email: "alice@example.com" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ success: true });
+		expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: "alice@example.com",
+				username: "alice",
+				resetUrl: expect.stringContaining("https://docklight.example.com/reset-password?token="),
+			})
+		);
+	});
+
+	it("should reset password and invalidate the reset token", async () => {
+		vi.mocked(getPasswordResetTokenByHash).mockReturnValue({
+			id: 1,
+			userId: 7,
+			tokenHash: "token-hash",
+			expiresAt: new Date(Date.now() + 1000 * 60 * 30).toISOString(),
+			usedAt: null,
+			createdAt: new Date().toISOString(),
+		});
+
+		const response = await request(createTestApp())
+			.post("/api/auth/reset-password")
+			.send({ token: "reset-token", password: "new-password" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ success: true });
+		expect(updateUser).toHaveBeenCalledWith(
+			7,
+			expect.objectContaining({ passwordHash: expect.any(String) })
+		);
+		expect(markPasswordResetTokenUsed).toHaveBeenCalledWith(hashResetToken("reset-token"));
+	});
+});

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -21,8 +21,6 @@ vi.mock("../lib/db.js", () => ({
 	getUserAuthStateById: vi.fn(),
 	createPasswordResetToken: vi.fn(),
 	deleteExpiredPasswordResetTokens: vi.fn(),
-	getPasswordResetTokenByHash: vi.fn(),
-	markPasswordResetTokenUsed: vi.fn(),
 	resetPasswordWithToken: vi.fn(),
 	updateUser: vi.fn(),
 }));
@@ -39,12 +37,7 @@ vi.mock("./util.js", () => ({
 }));
 
 import { hashResetToken } from "../lib/auth.js";
-import {
-	createPasswordResetToken,
-	getPasswordResetTokenByHash,
-	getUserByEmail,
-	resetPasswordWithToken,
-} from "../lib/db.js";
+import { createPasswordResetToken, getUserByEmail, resetPasswordWithToken } from "../lib/db.js";
 import { sendPasswordResetEmail } from "../lib/email.js";
 import { registerAuthRoutes } from "./auth.js";
 
@@ -137,15 +130,7 @@ describe("auth routes", () => {
 	});
 
 	it("should reset password and invalidate the reset token", async () => {
-		vi.mocked(getPasswordResetTokenByHash).mockReturnValue({
-			id: 1,
-			userId: 7,
-			tokenHash: "token-hash",
-			expiresAt: new Date(Date.now() + 1000 * 60 * 30).toISOString(),
-			usedAt: null,
-			createdAt: new Date().toISOString(),
-		});
-		vi.mocked(resetPasswordWithToken).mockReturnValue(true);
+		vi.mocked(resetPasswordWithToken).mockReturnValue(7);
 
 		const response = await request(createTestApp())
 			.post("/api/auth/reset-password")
@@ -155,7 +140,6 @@ describe("auth routes", () => {
 		expect(response.body).toEqual({ success: true });
 		expect(resetPasswordWithToken).toHaveBeenCalledWith(
 			hashResetToken("reset-token"),
-			7,
 			expect.any(String)
 		);
 	});

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -20,8 +20,10 @@ vi.mock("../lib/db.js", () => ({
 	getUserByEmail: vi.fn(),
 	getUserAuthStateById: vi.fn(),
 	createPasswordResetToken: vi.fn(),
+	deleteExpiredPasswordResetTokens: vi.fn(),
 	getPasswordResetTokenByHash: vi.fn(),
 	markPasswordResetTokenUsed: vi.fn(),
+	resetPasswordWithToken: vi.fn(),
 	updateUser: vi.fn(),
 }));
 
@@ -41,8 +43,7 @@ import {
 	createPasswordResetToken,
 	getPasswordResetTokenByHash,
 	getUserByEmail,
-	markPasswordResetTokenUsed,
-	updateUser,
+	resetPasswordWithToken,
 } from "../lib/db.js";
 import { sendPasswordResetEmail } from "../lib/email.js";
 import { registerAuthRoutes } from "./auth.js";
@@ -74,7 +75,6 @@ describe("auth routes", () => {
 			email: "alice@example.com",
 			password_hash: "hash",
 			role: "admin",
-			sessionVersion: 0,
 			createdAt: new Date().toISOString(),
 		});
 		vi.mocked(createPasswordResetToken).mockReturnValue({
@@ -110,7 +110,6 @@ describe("auth routes", () => {
 			email: "alice@example.com",
 			password_hash: "hash",
 			role: "admin",
-			sessionVersion: 0,
 			createdAt: new Date().toISOString(),
 		});
 		vi.mocked(createPasswordResetToken).mockReturnValue({
@@ -146,6 +145,7 @@ describe("auth routes", () => {
 			usedAt: null,
 			createdAt: new Date().toISOString(),
 		});
+		vi.mocked(resetPasswordWithToken).mockReturnValue(true);
 
 		const response = await request(createTestApp())
 			.post("/api/auth/reset-password")
@@ -153,10 +153,10 @@ describe("auth routes", () => {
 
 		expect(response.status).toBe(200);
 		expect(response.body).toEqual({ success: true });
-		expect(updateUser).toHaveBeenCalledWith(
+		expect(resetPasswordWithToken).toHaveBeenCalledWith(
+			hashResetToken("reset-token"),
 			7,
-			expect.objectContaining({ passwordHash: expect.any(String) })
+			expect.any(String)
 		);
-		expect(markPasswordResetTokenUsed).toHaveBeenCalledWith(hashResetToken("reset-token"));
 	});
 });

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,7 +1,26 @@
+import { randomBytes } from "crypto";
 import type express from "express";
-import { authMiddleware, clearAuthCookie, login, setAuthCookie } from "../lib/auth.js";
+import {
+	authMiddleware,
+	clearAuthCookie,
+	hashPassword,
+	hashResetToken,
+	login,
+	setAuthCookie,
+} from "../lib/auth.js";
 import { authRateLimiter, authCheckRateLimiter } from "../lib/rate-limiter.js";
+import {
+	createPasswordResetToken,
+	getPasswordResetTokenByHash,
+	getUserByEmail,
+	updateUser,
+	markPasswordResetTokenUsed,
+} from "../lib/db.js";
 import { safeAuditLogWithUserId } from "./util.js";
+
+function normalizeEmail(value: unknown): string {
+	return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
 
 export function registerAuthRoutes(app: express.Application): void {
 	app.post("/api/auth/login", authRateLimiter, async (req, res) => {
@@ -19,9 +38,61 @@ export function registerAuthRoutes(app: express.Application): void {
 		}
 
 		setAuthCookie(res, user);
-
 		safeAuditLogWithUserId(req, user.id, "login", null, { username });
+		res.json({ success: true });
+	});
 
+	app.post("/api/auth/forgot-password", authRateLimiter, async (req, res) => {
+		const email = normalizeEmail(req.body?.email);
+		if (!email) {
+			res.status(400).json({ error: "Email is required" });
+			return;
+		}
+
+		const user = getUserByEmail(email);
+		if (user?.email) {
+			const token = randomBytes(32).toString("hex");
+			const tokenHash = hashResetToken(token);
+			const expiresAt = new Date(Date.now() + 1000 * 60 * 30).toISOString();
+			createPasswordResetToken(user.id, tokenHash, expiresAt);
+			safeAuditLogWithUserId(req, user.id, "password:reset-request", null, { email });
+
+			if (process.env.NODE_ENV !== "production") {
+				res.json({ success: true, resetToken: token, resetUrl: `/reset-password?token=${token}` });
+				return;
+			}
+		}
+
+		res.json({ success: true });
+	});
+
+	app.post("/api/auth/reset-password", authRateLimiter, async (req, res) => {
+		const token = typeof req.body?.token === "string" ? req.body.token.trim() : "";
+		const password = typeof req.body?.password === "string" ? req.body.password : "";
+
+		if (!token) {
+			res.status(400).json({ error: "Token is required" });
+			return;
+		}
+		if (!password) {
+			res.status(400).json({ error: "Password is required" });
+			return;
+		}
+
+		const tokenHash = hashResetToken(token);
+		const resetToken = getPasswordResetTokenByHash(tokenHash);
+		if (
+			!resetToken ||
+			resetToken.usedAt !== null ||
+			new Date(resetToken.expiresAt).getTime() <= Date.now()
+		) {
+			res.status(400).json({ error: "Invalid or expired token" });
+			return;
+		}
+
+		updateUser(resetToken.userId, { passwordHash: await hashPassword(password) });
+		markPasswordResetTokenUsed(tokenHash);
+		safeAuditLogWithUserId(req, resetToken.userId, "password:reset", null, null);
 		res.json({ success: true });
 	});
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -8,14 +8,15 @@ import {
 	login,
 	setAuthCookie,
 } from "../lib/auth.js";
-import { authRateLimiter, authCheckRateLimiter } from "../lib/rate-limiter.js";
 import {
 	createPasswordResetToken,
+	deleteExpiredPasswordResetTokens,
 	getPasswordResetTokenByHash,
 	getUserByEmail,
-	updateUser,
-	markPasswordResetTokenUsed,
+	resetPasswordWithToken,
 } from "../lib/db.js";
+import { buildPasswordResetUrl, sendPasswordResetEmail } from "../lib/email.js";
+import { authRateLimiter, authCheckRateLimiter } from "../lib/rate-limiter.js";
 import { safeAuditLogWithUserId } from "./util.js";
 
 function normalizeEmail(value: unknown): string {
@@ -49,16 +50,25 @@ export function registerAuthRoutes(app: express.Application): void {
 			return;
 		}
 
+		deleteExpiredPasswordResetTokens();
+
 		const user = getUserByEmail(email);
 		if (user?.email) {
 			const token = randomBytes(32).toString("hex");
 			const tokenHash = hashResetToken(token);
 			const expiresAt = new Date(Date.now() + 1000 * 60 * 30).toISOString();
+			const resetUrl = buildPasswordResetUrl(token);
 			createPasswordResetToken(user.id, tokenHash, expiresAt);
 			safeAuditLogWithUserId(req, user.id, "password:reset-request", null, { email });
 
+			if (process.env.RESEND_API_KEY && process.env.RESEND_FROM_EMAIL) {
+				await sendPasswordResetEmail({ to: user.email, username: user.username, resetUrl });
+				res.json({ success: true });
+				return;
+			}
+
 			if (process.env.NODE_ENV !== "production") {
-				res.json({ success: true, resetToken: token, resetUrl: `/reset-password?token=${token}` });
+				res.json({ success: true, resetToken: token, resetUrl });
 				return;
 			}
 		}
@@ -90,8 +100,15 @@ export function registerAuthRoutes(app: express.Application): void {
 			return;
 		}
 
-		updateUser(resetToken.userId, { passwordHash: await hashPassword(password) });
-		markPasswordResetTokenUsed(tokenHash);
+		const success = resetPasswordWithToken(
+			tokenHash,
+			resetToken.userId,
+			await hashPassword(password)
+		);
+		if (!success) {
+			res.status(400).json({ error: "Invalid or expired token" });
+			return;
+		}
 		safeAuditLogWithUserId(req, resetToken.userId, "password:reset", null, null);
 		res.json({ success: true });
 	});

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -11,7 +11,6 @@ import {
 import {
 	createPasswordResetToken,
 	deleteExpiredPasswordResetTokens,
-	getPasswordResetTokenByHash,
 	getUserByEmail,
 	resetPasswordWithToken,
 } from "../lib/db.js";
@@ -90,26 +89,12 @@ export function registerAuthRoutes(app: express.Application): void {
 		}
 
 		const tokenHash = hashResetToken(token);
-		const resetToken = getPasswordResetTokenByHash(tokenHash);
-		if (
-			!resetToken ||
-			resetToken.usedAt !== null ||
-			new Date(resetToken.expiresAt).getTime() <= Date.now()
-		) {
+		const userId = resetPasswordWithToken(tokenHash, await hashPassword(password));
+		if (userId === null) {
 			res.status(400).json({ error: "Invalid or expired token" });
 			return;
 		}
-
-		const success = resetPasswordWithToken(
-			tokenHash,
-			resetToken.userId,
-			await hashPassword(password)
-		);
-		if (!success) {
-			res.status(400).json({ error: "Invalid or expired token" });
-			return;
-		}
-		safeAuditLogWithUserId(req, resetToken.userId, "password:reset", null, null);
+		safeAuditLogWithUserId(req, userId, "password:reset", null, null);
 		res.json({ success: true });
 	});
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/db.js";
 import { authMiddleware, requireAdmin, hashPassword } from "../lib/auth.js";
 import { clearPrefix, get, set } from "../lib/cache.js";
-import { safeAuditLog } from "./util.js";
+import { safeAuditLog, handleDbError } from "./util.js";
 
 export function registerUserRoutes(app: express.Application): void {
 	app.get("/api/users", authMiddleware, requireAdmin, (_req, res) => {
@@ -62,15 +62,7 @@ export function registerUserRoutes(app: express.Application): void {
 			clearPrefix("users:");
 			res.status(201).json(user);
 		} catch (err: unknown) {
-			const error = err as { code?: number; message?: string };
-			if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
-				const msg = error.message.includes("users.email")
-					? "Email already exists"
-					: "Username already exists";
-				res.status(409).json({ error: msg });
-			} else {
-				res.status(500).json({ error: "Internal server error" });
-			}
+			handleDbError(err, res);
 		}
 	});
 
@@ -132,15 +124,7 @@ export function registerUserRoutes(app: express.Application): void {
 		try {
 			updateUser(id, updates);
 		} catch (err: unknown) {
-			const error = err as { code?: number; message?: string };
-			if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
-				const msg = error.message.includes("users.email")
-					? "Email already exists"
-					: "Username already exists";
-				res.status(409).json({ error: msg });
-			} else {
-				res.status(500).json({ error: "Internal server error" });
-			}
+			handleDbError(err, res);
 			return;
 		}
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -3,10 +3,9 @@ import {
 	getAllUsers,
 	createUser,
 	getUserById,
-	updateUser,
+	updateUserWithGuard,
 	deleteUser,
 	type UserRole,
-	demoteAdminWithGuard,
 	deleteUserWithAdminGuard,
 } from "../lib/db.js";
 import { authMiddleware, requireAdmin, hashPassword } from "../lib/auth.js";
@@ -90,15 +89,7 @@ export function registerUserRoutes(app: express.Application): void {
 				});
 				return;
 			}
-			if (existing.role === "admin" && role !== "admin") {
-				const result = demoteAdminWithGuard(id, role);
-				if (!result.success) {
-					res.status(400).json({ error: result.error });
-					return;
-				}
-			} else {
-				updates.role = role;
-			}
+			updates.role = role;
 		}
 
 		if (email !== undefined) {
@@ -122,7 +113,11 @@ export function registerUserRoutes(app: express.Application): void {
 		}
 
 		try {
-			updateUser(id, updates);
+			const result = updateUserWithGuard(id, updates);
+			if (!result.success) {
+				res.status(400).json({ error: result.error });
+				return;
+			}
 		} catch (err: unknown) {
 			handleDbError(err, res);
 			return;

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -29,7 +29,7 @@ export function registerUserRoutes(app: express.Application): void {
 	});
 
 	app.post("/api/users", authMiddleware, requireAdmin, async (req, res) => {
-		const { username, password, role } = req.body;
+		const { username, password, role, email } = req.body;
 
 		if (!username || typeof username !== "string") {
 			res.status(400).json({ error: "Username is required" });
@@ -46,11 +46,18 @@ export function registerUserRoutes(app: express.Application): void {
 			return;
 		}
 
+		const normalizedEmail =
+			typeof email === "string" && email.trim().length > 0 ? email.trim().toLowerCase() : null;
+		if (normalizedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+			res.status(400).json({ error: "Invalid email address" });
+			return;
+		}
+
 		try {
 			const passwordHash = await hashPassword(password);
-			const user = createUser(username, passwordHash, role);
+			const user = createUser(username, passwordHash, role, normalizedEmail);
 
-			safeAuditLog(req, "user:create", username, { username, role });
+			safeAuditLog(req, "user:create", username, { username, role, email: normalizedEmail });
 
 			clearPrefix("users:");
 			res.status(201).json(user);
@@ -66,7 +73,7 @@ export function registerUserRoutes(app: express.Application): void {
 
 	app.put("/api/users/:id", authMiddleware, requireAdmin, async (req, res) => {
 		const id = Number.parseInt(req.params.id as string);
-		const { role, password } = req.body;
+		const { role, password, email } = req.body;
 
 		if (Number.isNaN(id)) {
 			res.status(400).json({ error: "Invalid user ID" });
@@ -79,7 +86,7 @@ export function registerUserRoutes(app: express.Application): void {
 			return;
 		}
 
-		const updates: { role?: UserRole; passwordHash?: string } = {};
+		const updates: { role?: UserRole; passwordHash?: string; email?: string | null } = {};
 
 		if (role !== undefined) {
 			if (!["admin", "operator", "viewer"].includes(role)) {
@@ -99,6 +106,16 @@ export function registerUserRoutes(app: express.Application): void {
 			}
 		}
 
+		if (email !== undefined) {
+			const normalizedEmail =
+				typeof email === "string" && email.trim().length > 0 ? email.trim().toLowerCase() : null;
+			if (normalizedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+				res.status(400).json({ error: "Invalid email address" });
+				return;
+			}
+			updates.email = normalizedEmail;
+		}
+
 		if (password !== undefined) {
 			if (typeof password !== "string" || password.length === 0) {
 				res.status(400).json({
@@ -114,6 +131,7 @@ export function registerUserRoutes(app: express.Application): void {
 		safeAuditLog(req, "user:update", existing.username, {
 			username: existing.username,
 			role,
+			email: updates.email,
 			passwordChanged: password !== undefined,
 		});
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -57,14 +57,17 @@ export function registerUserRoutes(app: express.Application): void {
 			const passwordHash = await hashPassword(password);
 			const user = createUser(username, passwordHash, role, normalizedEmail);
 
-			safeAuditLog(req, "user:create", username, { username, role, email: normalizedEmail });
+			safeAuditLog(req, "user:create", username, { username, role, emailSet: !!normalizedEmail });
 
 			clearPrefix("users:");
 			res.status(201).json(user);
 		} catch (err: unknown) {
 			const error = err as { code?: number; message?: string };
 			if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
-				res.status(409).json({ error: "Username already exists" });
+				const msg = error.message.includes("users.email")
+					? "Email already exists"
+					: "Username already exists";
+				res.status(409).json({ error: msg });
 			} else {
 				res.status(500).json({ error: "Internal server error" });
 			}
@@ -126,12 +129,25 @@ export function registerUserRoutes(app: express.Application): void {
 			updates.passwordHash = await hashPassword(password);
 		}
 
-		updateUser(id, updates);
+		try {
+			updateUser(id, updates);
+		} catch (err: unknown) {
+			const error = err as { code?: number; message?: string };
+			if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
+				const msg = error.message.includes("users.email")
+					? "Email already exists"
+					: "Username already exists";
+				res.status(409).json({ error: msg });
+			} else {
+				res.status(500).json({ error: "Internal server error" });
+			}
+			return;
+		}
 
 		safeAuditLog(req, "user:update", existing.username, {
 			username: existing.username,
 			role,
-			email: updates.email,
+			emailChanged: updates.email !== undefined,
 			passwordChanged: password !== undefined,
 		});
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -45,6 +45,11 @@ export function registerUserRoutes(app: express.Application): void {
 			return;
 		}
 
+		if (email !== undefined && email !== null && typeof email !== "string") {
+			res.status(400).json({ error: "Invalid email address" });
+			return;
+		}
+
 		const normalizedEmail =
 			typeof email === "string" && email.trim().length > 0 ? email.trim().toLowerCase() : null;
 		if (normalizedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
@@ -93,6 +98,10 @@ export function registerUserRoutes(app: express.Application): void {
 		}
 
 		if (email !== undefined) {
+			if (email !== null && typeof email !== "string") {
+				res.status(400).json({ error: "Invalid email address" });
+				return;
+			}
 			const normalizedEmail =
 				typeof email === "string" && email.trim().length > 0 ? email.trim().toLowerCase() : null;
 			if (normalizedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {

--- a/server/routes/util.ts
+++ b/server/routes/util.ts
@@ -169,6 +169,7 @@ export function handleDbError(err: unknown, res: express.Response): void {
 			: "Username already exists";
 		res.status(409).json({ error: msg });
 	} else {
+		logger.error({ err }, "Database operation failed");
 		res.status(500).json({ error: "Internal server error" });
 	}
 }

--- a/server/routes/util.ts
+++ b/server/routes/util.ts
@@ -154,3 +154,18 @@ export function safeAuditLogWithUserId(
 		logger.error({ err: error as Error, action, userId }, "Failed to write audit log");
 	}
 }
+
+/**
+ * Handles database errors, mapping SQLite unique constraints to proper 409 responses
+ */
+export function handleDbError(err: unknown, res: express.Response): void {
+	const error = err as { code?: number; message?: string };
+	if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
+		const msg = error.message.includes("users.email")
+			? "Email already exists"
+			: "Username already exists";
+		res.status(409).json({ error: msg });
+	} else {
+		res.status(500).json({ error: "Internal server error" });
+	}
+}

--- a/server/routes/util.ts
+++ b/server/routes/util.ts
@@ -159,8 +159,11 @@ export function safeAuditLogWithUserId(
  * Handles database errors, mapping SQLite unique constraints to proper 409 responses
  */
 export function handleDbError(err: unknown, res: express.Response): void {
-	const error = err as { code?: number; message?: string };
-	if (error.code === 19 && error.message?.includes("UNIQUE constraint failed")) {
+	const error = err as { code?: string; message?: string };
+	if (
+		(error.code === "SQLITE_CONSTRAINT" || error.code === "SQLITE_CONSTRAINT_UNIQUE") &&
+		error.message?.includes("UNIQUE constraint failed")
+	) {
 		const msg = error.message.includes("users.email")
 			? "Email already exists"
 			: "Username already exists";


### PR DESCRIPTION
## What

- Added email support to users across the backend, admin UI, and shared schemas.
- Added password reset token storage and auth endpoints for forgot-password/reset-password.
- Updated the login page and tests to support the reset flow.

## Why

Issue #136 asks for email-linked users and a password recovery flow.
This gives Docklight a practical recovery path without changing the existing login model.

## How

- Extended the SQLite users schema and user helpers to store `email`.
- Added hashed password-reset tokens with expiration and one-time use tracking.
- Exposed `/api/auth/forgot-password` and `/api/auth/reset-password` endpoints.
- Updated the users screen to show and edit email.
- Added login-page UI and tests for the reset-request flow.

## Checklist

- [x] Tests added or updated
- [x] Validation run: `npm run typecheck` (server + client)
- [x] Validation run: `npm test` (server + client)
- [x] Validation run: `npm run lint` (server + client)
- [ ] Documentation updated
- [ ] No breaking changes (or breaking changes documented above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional email support across user accounts (admin UI now shows, creates, and edits email) and backup/restore (backup v1.1).
  * Added password reset flow: request reset links and reset passwords, with optional email delivery via configured email provider; links are generated from the app URL.
* **Bug Fixes**
  * Login now accepts credentials by username or email.
  * Improved reset-token outcomes (invalid/expired vs already-used) and clearer handling of duplicate user/username/email on save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->