### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,12 @@ Server (.env or environment):
 - Use Tailwind 4 with `@tailwindcss/postcss`
 - Use `tw-animate-css` for animations
 - Client components use the `cn()` helper for class merging
+
+## Cursor Cloud specific instructions
+
+- Toolchain: `bun` and `just` are required and are installed at the system level (`/usr/local/bin`). Node 22 is preinstalled. The startup update script runs `bun install` in both `server/` and `client/`; standard commands live in the `## Commands` section above.
+- Run dev servers (long-lived) in separate tmux sessions, not one-shot: backend `cd server && bun run dev` (port 3001), frontend `cd client && bun run dev` (port 5173, proxies `/api` → 3001). Do not use `just build`/`bun start` for development.
+- `JWT_SECRET` is only mandatory in production; in dev the server boots with a built-in dev secret. There is no `server/.env` committed — export `JWT_SECRET` if you want a custom one.
+- No Dokku host is available in this environment. Login, user management, the audit log, and the SQLite-backed dashboard cards (CPU/Mem/Disk run via local shell) all work. Any real Dokku action (apps/databases/domains/SSL) will error unless `DOCKLIGHT_DOKKU_SSH_TARGET` points to a reachable Dokku host — this is expected, not a setup failure. Leave `DOCKLIGHT_DOKKU_SSH_TARGET` unset in dev so commands run locally instead of trying the example `dokku@172.17.0.1`.
+- No signup UI: bootstrap an admin with `cd server && npx tsx createUser.ts <user> <password>` (creates/updates an `admin` user in the SQLite DB at `data/docklight.db`). Re-running updates the password.
+- `just test` runs Vitest for both projects (no Dokku needed; deps are mocked). Playwright E2E (`cd client && bun run test:e2e`) builds the client and mocks all `/api` responses, so it also needs no real backend — but requires Playwright browsers to be installed first.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Docklight development environment for Cursor Cloud agents, and documents durable, non-obvious startup caveats in `AGENTS.md`.

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the required toolchain (`bun`/`just`), tmux-based dev servers, dev-only `JWT_SECRET`, admin bootstrap via `createUser.ts`, and the expected "no Dokku host" behavior.
- Registered a minimal startup update script (`bun install` in `server/` and `client/`).

## Verification

Installed `bun` 1.3.14 and `just` 1.55.1 (Node 22 preinstalled), installed deps, and ran the full quality suite plus an end-to-end login demo.

| Check | Command | Result |
| --- | --- | --- |
| Lint | `just lint` | pass (2 pre-existing infos) |
| Typecheck | `just typecheck` | pass |
| Tests | `just test` | 1037 passed (786 server + 251 client) |
| Build | `just build` | pass |
| Run + login | `bun run dev` (server 3001 + client 5173) | admin login → dashboard |

Login flow demonstrated end-to-end (login page → authenticated dashboard with live CPU/Mem/Disk health):

[docklight_login_dashboard_demo.mp4](https://cursor.com/agents/bc-5a0395a2-557a-4429-ae43-9b4644876cee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocklight_login_dashboard_demo.mp4)

[Docklight login page](https://cursor.com/agents/bc-5a0395a2-557a-4429-ae43-9b4644876cee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocklight_login_page.webp)
[Docklight dashboard after login](https://cursor.com/agents/bc-5a0395a2-557a-4429-ae43-9b4644876cee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocklight_dashboard.webp)

No Dokku host is available in this environment, so real app/database/SSL actions error by design; login, user management, audit log, and SQLite-backed dashboard cards work fully.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a0395a2-557a-4429-ae43-9b4644876cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a0395a2-557a-4429-ae43-9b4644876cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

