### PR TITLE
fix(server): stop quoting env var keys in dokku config:set

### DIFF
--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -1,6 +1,9 @@
 import { executeCommand, type CommandResult } from "./executor.js";
 import { isValidAppName } from "./apps.js";
 import { DokkuCommands } from "./dokku.js";
+import { validateConfigKey } from "./env-config-key.js";
+
+export { validateConfigKey } from "./env-config-key.js";
 
 export async function getConfig(
 	name: string
@@ -65,10 +68,9 @@ export async function setConfig(
 		};
 	}
 
-	// Key must be alphanumeric + underscore (env var convention)
-	const sanitizedKey = key.replace(/[^a-zA-Z0-9_]/g, "");
-	if (sanitizedKey !== key) {
-		return { error: "Invalid characters in key", command: "", exitCode: 400 };
+	const keyError = validateConfigKey(key);
+	if (keyError) {
+		return { error: keyError, command: "", exitCode: 400 };
 	}
 
 	// Value: block shell injection but allow common chars like quotes, @, #, etc.
@@ -80,7 +82,7 @@ export async function setConfig(
 		};
 	}
 
-	const command = DokkuCommands.configSet(name, sanitizedKey, value);
+	const command = DokkuCommands.configSet(name, key, value);
 
 	try {
 		return executeCommand(command);
@@ -106,18 +108,12 @@ export async function unsetConfig(
 		};
 	}
 
-	// Sanitize key to prevent shell injection
-	const sanitizedKey = key.replace(/[^a-zA-Z0-9_]/g, "");
-
-	if (sanitizedKey !== key) {
-		return {
-			error: "Invalid characters in key",
-			command: "",
-			exitCode: 400,
-		};
+	const unsetKeyError = validateConfigKey(key);
+	if (unsetKeyError) {
+		return { error: unsetKeyError, command: "", exitCode: 400 };
 	}
 
-	const command = DokkuCommands.configUnset(name, sanitizedKey);
+	const command = DokkuCommands.configUnset(name, key);
 
 	try {
 		return executeCommand(command);

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -80,14 +80,20 @@ describe("DokkuCommands", () => {
 			expect(DokkuCommands.configShow("my-app")).toBe("dokku config:show my-app");
 		});
 
-		it("configSet returns config:set command with quoted value", () => {
+		it("configSet returns config:set command with quoted value only", () => {
 			expect(DokkuCommands.configSet("my-app", "KEY", "value")).toBe(
-				"dokku config:set 'my-app' 'KEY'='value'"
+				"dokku config:set 'my-app' KEY='value'"
 			);
 		});
 
-		it("configUnset returns config:unset command", () => {
-			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' 'KEY'");
+		it("configSet does not quote env var keys", () => {
+			expect(
+				DokkuCommands.configSet("my-app", "SUPER_ADMIN_BOOTSTRAP_EMAIL", "admin@example.com")
+			).toBe("dokku config:set 'my-app' SUPER_ADMIN_BOOTSTRAP_EMAIL='admin@example.com'");
+		});
+
+		it("configUnset returns config:unset command without quoting key", () => {
+			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' KEY");
 		});
 	});
 

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -95,6 +95,12 @@ describe("DokkuCommands", () => {
 		it("configUnset returns config:unset command without quoting key", () => {
 			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' KEY");
 		});
+
+		it("configSet rejects invalid keys before building command", () => {
+			expect(() => DokkuCommands.configSet("my-app", "KEY;evil", "x")).toThrow(
+				/Invalid characters/
+			);
+		});
 	});
 
 	describe("plugins", () => {

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -1,4 +1,5 @@
 import { executeCommand } from "./executor.js";
+import { assertValidConfigKey } from "./env-config-key.js";
 import { shellQuote } from "./shell.js";
 
 export interface GitSyncResult {
@@ -153,9 +154,14 @@ export const DokkuCommands: DokkuCommands = {
 
 	// Config
 	configShow: (app: string): string => `dokku config:show ${app}`,
-	configSet: (app: string, key: string, value: string): string =>
-		`dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`,
-	configUnset: (app: string, key: string): string => `dokku config:unset ${shellQuote(app)} ${key}`,
+	configSet: (app: string, key: string, value: string): string => {
+		assertValidConfigKey(key);
+		return `dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`;
+	},
+	configUnset: (app: string, key: string): string => {
+		assertValidConfigKey(key);
+		return `dokku config:unset ${shellQuote(app)} ${key}`;
+	},
 
 	// Plugins (read-only)
 	pluginList: (): string => "dokku plugin:list",

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -154,9 +154,8 @@ export const DokkuCommands: DokkuCommands = {
 	// Config
 	configShow: (app: string): string => `dokku config:show ${app}`,
 	configSet: (app: string, key: string, value: string): string =>
-		`dokku config:set ${shellQuote(app)} ${shellQuote(key)}=${shellQuote(value)}`,
-	configUnset: (app: string, key: string): string =>
-		`dokku config:unset ${shellQuote(app)} ${shellQuote(key)}`,
+		`dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`,
+	configUnset: (app: string, key: string): string => `dokku config:unset ${shellQuote(app)} ${key}`,
 
 	// Plugins (read-only)
 	pluginList: (): string => "dokku plugin:list",

--- a/server/lib/env-config-key.test.ts
+++ b/server/lib/env-config-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { assertValidConfigKey, validateConfigKey } from "./env-config-key.js";
+
+describe("validateConfigKey", () => {
+	it("accepts valid env var names", () => {
+		expect(validateConfigKey("SUPER_ADMIN_BOOTSTRAP_EMAIL")).toBeNull();
+		expect(validateConfigKey("NODE_ENV")).toBeNull();
+	});
+
+	it("rejects injection attempts", () => {
+		expect(validateConfigKey("KEY;rm -rf /")).not.toBeNull();
+		expect(validateConfigKey("'KEY'")).not.toBeNull();
+		expect(validateConfigKey("")).not.toBeNull();
+	});
+});
+
+describe("assertValidConfigKey", () => {
+	it("throws for invalid keys", () => {
+		expect(() => assertValidConfigKey("bad key")).toThrow(/Invalid characters/);
+	});
+});

--- a/server/lib/env-config-key.ts
+++ b/server/lib/env-config-key.ts
@@ -1,0 +1,18 @@
+const CONFIG_KEY_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+export function validateConfigKey(key: string): string | null {
+	if (typeof key !== "string" || key.length === 0) {
+		return "Config key is required";
+	}
+	if (!CONFIG_KEY_PATTERN.test(key)) {
+		return "Invalid characters in key";
+	}
+	return null;
+}
+
+export function assertValidConfigKey(key: string): void {
+	const error = validateConfigKey(key);
+	if (error) {
+		throw new Error(error);
+	}
+}

--- a/server/routes/app-config.ts
+++ b/server/routes/app-config.ts
@@ -1,5 +1,5 @@
 import type express from "express";
-import { getConfig, setConfig, unsetConfig } from "../lib/config.js";
+import { getConfig, setConfig, unsetConfig, validateConfigKey } from "../lib/config.js";
 import { clearPrefix } from "../lib/cache.js";
 import { authMiddleware, requireOperator } from "../lib/auth.js";
 import { DokkuCommands } from "../lib/dokku.js";
@@ -22,6 +22,11 @@ export function registerAppConfigRoutes(app: express.Application): void {
 		if (isSSERequest(req)) {
 			if (!isValidAppName(name) || !key) {
 				res.status(400).json({ error: "Invalid app name or key" });
+				return;
+			}
+			const keyError = validateConfigKey(key);
+			if (keyError) {
+				res.status(400).json({ error: keyError });
 				return;
 			}
 			await streamAction(req, res, {
@@ -50,6 +55,11 @@ export function registerAppConfigRoutes(app: express.Application): void {
 		if (isSSERequest(req)) {
 			if (!isValidAppName(name) || !key) {
 				res.status(400).json({ error: "Invalid app name or key" });
+				return;
+			}
+			const unsetKeyError = validateConfigKey(key);
+			if (unsetKeyError) {
+				res.status(400).json({ error: unsetKeyError });
 				return;
 			}
 			await streamAction(req, res, {


### PR DESCRIPTION
## What

Fix Dokku `config:set` and `config:unset` command builders so environment variable **keys** are not wrapped in single quotes. Updates `server/lib/dokku.ts` and related tests in `server/lib/dokku.test.ts`.

## Why

Setting env vars from the app Config UI (SSE `config:set`) failed with errors like `Invalid key name: 'SUPER_ADMIN_BOOTSTRAP_EMAIL'`. Dokku was receiving quoted key names as literal identifiers.

## How

- `configSet`: quote app name and value only — `KEY=${shellQuote(value)}` instead of `${shellQuote(key)}=${shellQuote(value)}`
- `configUnset`: pass the key unquoted (keys are already validated as `[a-zA-Z0-9_]` in `setConfig` / `unsetConfig`)
- Added a test case for `SUPER_ADMIN_BOOTSTRAP_EMAIL`

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)