### PR TITLE
feat: detect shared host ports (SSL / Let's Encrypt conflicts)

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -1,6 +1,7 @@
 export const queryKeys = {
 	apps: {
 		all: ["apps"] as const,
+		portConflicts: ["apps", "port-conflicts"] as const,
 		detail: (name: string) => ["apps", name] as const,
 		config: (name: string) => ["apps", name, "config"] as const,
 		domains: (name: string) => ["apps", name, "domains"] as const,

--- a/client/src/lib/routing-issues.test.ts
+++ b/client/src/lib/routing-issues.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildRoutingIssues } from "./routing-issues.js";
+import { buildRoutingIssues } from "@/lib/routing-issues.js";
 
 describe("buildRoutingIssues", () => {
 	it("flags shared host port 80 between apps", () => {

--- a/client/src/lib/routing-issues.test.ts
+++ b/client/src/lib/routing-issues.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { buildRoutingIssues } from "./routing-issues.js";
+
+describe("buildRoutingIssues", () => {
+	it("flags shared host port 80 between apps", () => {
+		const issues = buildRoutingIssues(
+			"docklight",
+			[{ scheme: "http", hostPort: 80, containerPort: 3001 }],
+			[{ scheme: "http", hostPort: 80, apps: ["docklight", "ai-flow-staging"] }]
+		);
+		expect(issues.some((i) => i.id.startsWith("conflict-http-80"))).toBe(true);
+		expect(issues.some((i) => i.id === "ssl-http80-conflict")).toBe(true);
+	});
+
+	it("warns when http is not on port 80", () => {
+		const issues = buildRoutingIssues(
+			"docklight",
+			[{ scheme: "http", hostPort: 8008, containerPort: 3001 }],
+			[]
+		);
+		expect(issues.some((i) => i.id === "no-http-80")).toBe(true);
+	});
+});

--- a/client/src/lib/routing-issues.ts
+++ b/client/src/lib/routing-issues.ts
@@ -1,4 +1,4 @@
-import type { PortConflict, PortMapping } from "./schemas.js";
+import type { PortConflict, PortMapping } from "@/lib/schemas.js";
 
 export interface RoutingIssue {
 	id: string;
@@ -26,7 +26,11 @@ export function buildRoutingIssues(
 			title: `Host port ${conflict.hostPort} (${conflict.scheme}) is shared with other apps`,
 			detail: `These apps all map ${conflict.scheme} to host port ${conflict.hostPort}: ${conflict.apps.join(", ")}. Only one app can reliably own that port — this often causes wrong TLS certificates (SNI) and Let's Encrypt HTTP-01 failures (404 on acme-challenge). Give each public app its own host port, or map only one app to port 80 for HTTP.`,
 		});
-		if (others.length > 0 && conflict.scheme === "http" && conflict.hostPort === 80) {
+		if (
+			others.length > 0 &&
+			conflict.scheme.toLowerCase() === "http" &&
+			conflict.hostPort === 80
+		) {
 			issues.push({
 				id: "ssl-http80-conflict",
 				severity: "error",
@@ -36,8 +40,10 @@ export function buildRoutingIssues(
 		}
 	}
 
-	const hasHttp80 = ports.some((p) => p.scheme === "http" && p.hostPort === 80);
-	if (!hasHttp80 && ports.some((p) => p.scheme === "http")) {
+	const hasHttp80 = ports.some(
+		(p) => p.scheme.toLowerCase() === "http" && p.hostPort === 80
+	);
+	if (!hasHttp80 && ports.some((p) => p.scheme.toLowerCase() === "http")) {
 		issues.push({
 			id: "no-http-80",
 			severity: "warning",

--- a/client/src/lib/routing-issues.ts
+++ b/client/src/lib/routing-issues.ts
@@ -1,0 +1,61 @@
+import type { PortConflict, PortMapping } from "./schemas.js";
+
+export interface RoutingIssue {
+	id: string;
+	severity: "error" | "warning";
+	title: string;
+	detail: string;
+}
+
+export function buildRoutingIssues(
+	appName: string,
+	ports: PortMapping[],
+	conflicts: PortConflict[]
+): RoutingIssue[] {
+	const issues: RoutingIssue[] = [];
+	const normalizedApp = appName.toLowerCase();
+
+	for (const conflict of conflicts) {
+		if (!conflict.apps.map((a) => a.toLowerCase()).includes(normalizedApp)) {
+			continue;
+		}
+		const others = conflict.apps.filter((a) => a.toLowerCase() !== normalizedApp);
+		issues.push({
+			id: `conflict-${conflict.scheme}-${conflict.hostPort}`,
+			severity: "error",
+			title: `Host port ${conflict.hostPort} (${conflict.scheme}) is shared with other apps`,
+			detail: `These apps all map ${conflict.scheme} to host port ${conflict.hostPort}: ${conflict.apps.join(", ")}. Only one app can reliably own that port — this often causes wrong TLS certificates (SNI) and Let's Encrypt HTTP-01 failures (404 on acme-challenge). Give each public app its own host port, or map only one app to port 80 for HTTP.`,
+		});
+		if (others.length > 0 && conflict.scheme === "http" && conflict.hostPort === 80) {
+			issues.push({
+				id: "ssl-http80-conflict",
+				severity: "error",
+				title: "Let's Encrypt cannot complete while multiple apps use HTTP port 80",
+				detail: `Remove or change the port 80 mapping on ${others.join(", ")} (or on ${appName}) so a single app serves HTTP on 80 for each hostname, then retry Enable Let's Encrypt.`,
+			});
+		}
+	}
+
+	const hasHttp80 = ports.some((p) => p.scheme === "http" && p.hostPort === 80);
+	if (!hasHttp80 && ports.some((p) => p.scheme === "http")) {
+		issues.push({
+			id: "no-http-80",
+			severity: "warning",
+			title: "HTTP is not mapped to host port 80",
+			detail:
+				"Let's Encrypt HTTP-01 checks http://your-domain/.well-known/acme-challenge/ on port 80. Map http:80:<container-port> (Docklight uses container port 3001) unless another reverse proxy terminates HTTP correctly.",
+		});
+	}
+
+	if (ports.length === 0) {
+		issues.push({
+			id: "no-ports",
+			severity: "warning",
+			title: "No proxy port mappings",
+			detail:
+				"Dokku may assign a random high port. Add http:80:<container-port> before enabling HTTPS on a custom domain.",
+		});
+	}
+
+	return issues;
+}

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -158,17 +158,23 @@ export type PortsResponse = z.infer<typeof PortsResponseSchema>;
 
 const PortConflictSchema = z.object({
 	scheme: z.string(),
-	hostPort: z.number(),
+	hostPort: z.number().int().min(1).max(65535),
 	apps: z.array(z.string()),
 });
 
-export type PortConflict = z.infer<typeof PortConflictSchema>;
+export interface PortConflict {
+	scheme: string;
+	hostPort: number;
+	apps: string[];
+}
 
 export const PortConflictsResponseSchema = z.object({
 	conflicts: z.array(PortConflictSchema),
 });
 
-export type PortConflictsResponse = z.infer<typeof PortConflictsResponseSchema>;
+export interface PortConflictsResponse {
+	conflicts: PortConflict[];
+}
 
 // Proxy report schema
 export const ProxyReportSchema = z.object({

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -156,6 +156,20 @@ export const PortsResponseSchema = z.object({
 
 export type PortsResponse = z.infer<typeof PortsResponseSchema>;
 
+const PortConflictSchema = z.object({
+	scheme: z.string(),
+	hostPort: z.number(),
+	apps: z.array(z.string()),
+});
+
+export type PortConflict = z.infer<typeof PortConflictSchema>;
+
+export const PortConflictsResponseSchema = z.object({
+	conflicts: z.array(PortConflictSchema),
+});
+
+export type PortConflictsResponse = z.infer<typeof PortConflictsResponseSchema>;
+
 // Proxy report schema
 export const ProxyReportSchema = z.object({
 	enabled: z.boolean(),

--- a/client/src/pages/AppDetail/AppPorts.tsx
+++ b/client/src/pages/AppDetail/AppPorts.tsx
@@ -51,12 +51,14 @@ export function AppPorts({
 					<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-tertiary" />
 				</div>
 			) : error ? (
-				<div className={alertBannerClass("error")}>
-					{error}
-				</div>
+				<div className={alertBannerClass("error")}>{error}</div>
 			) : (
 				<div className="space-y-6">
 					<div>
+						<p className="text-sm text-muted-foreground mb-3">
+							Each app should use a unique host port. Sharing port 80 between apps breaks HTTPS and
+							Let&apos;s Encrypt.
+						</p>
 						<h3 className="text-sm font-medium text-foreground mb-3">Port Mappings</h3>
 
 						{ports.length > 0 ? (

--- a/client/src/pages/AppDetail/AppRoutingIssues.tsx
+++ b/client/src/pages/AppDetail/AppRoutingIssues.tsx
@@ -1,4 +1,4 @@
-import type { RoutingIssue } from "../../lib/routing-issues.js";
+import type { RoutingIssue } from "@/lib/routing-issues.js";
 import { alertBannerClass } from "@/lib/status-styles.js";
 
 interface AppRoutingIssuesProps {

--- a/client/src/pages/AppDetail/AppRoutingIssues.tsx
+++ b/client/src/pages/AppDetail/AppRoutingIssues.tsx
@@ -1,0 +1,31 @@
+import type { RoutingIssue } from "../../lib/routing-issues.js";
+import { alertBannerClass } from "@/lib/status-styles.js";
+
+interface AppRoutingIssuesProps {
+	issues: RoutingIssue[];
+	loading?: boolean;
+}
+
+export function AppRoutingIssues({ issues, loading }: AppRoutingIssuesProps) {
+	if (loading) {
+		return null;
+	}
+	if (issues.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="space-y-3 mb-6">
+			{issues.map((issue) => (
+				<div
+					key={issue.id}
+					className={alertBannerClass(issue.severity === "error" ? "error" : "warning")}
+					role="alert"
+				>
+					<p className="font-medium">{issue.title}</p>
+					<p className="text-sm mt-1 opacity-90">{issue.detail}</p>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/client/src/pages/AppDetail/index.tsx
+++ b/client/src/pages/AppDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { z } from "zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -21,10 +21,12 @@ import {
 	GitInfoSchema,
 	NetworkReportSchema,
 	type PortMapping,
+	PortConflictsResponseSchema,
 	PortsResponseSchema,
 	ProxyReportSchema,
 	SSLStatusSchema,
 } from "../../lib/schemas.js";
+import { buildRoutingIssues } from "../../lib/routing-issues.js";
 import { AppDetailHeader } from "./AppDetailHeader.js";
 import { AppOverview } from "./AppOverview.js";
 import { AppLogs } from "./AppLogs.js";
@@ -33,6 +35,7 @@ import { AppDomains } from "./AppDomains.js";
 import { AppSSL } from "./AppSSL.js";
 import { AppDeployment } from "./AppDeployment.js";
 import { AppPorts } from "./AppPorts.js";
+import { AppRoutingIssues } from "./AppRoutingIssues.js";
 import { AppBuildpacks } from "./AppBuildpacks.js";
 import { AppDockerOptions } from "./AppDockerOptions.js";
 import { AppNetwork } from "./AppNetwork.js";
@@ -165,6 +168,7 @@ export function AppDetail() {
 	const sslError = sslErrorData?.message || null;
 
 	const settingsEnabled = activeTab === "settings" && !!name;
+	const portsQueryEnabled = (activeTab === "settings" || activeTab === "ssl") && !!name;
 
 	// Deployment settings query
 	const {
@@ -195,7 +199,7 @@ export function AppDetail() {
 	} = useQuery({
 		queryKey: queryKeys.apps.ports(name || ""),
 		queryFn: () => apiFetch(`/apps/${encodeURIComponent(name || "")}/ports`, PortsResponseSchema),
-		enabled: settingsEnabled,
+		enabled: portsQueryEnabled,
 	});
 	const ports = portsData?.ports ?? [];
 	const portsError = portsErrorData?.message || null;
@@ -208,6 +212,25 @@ export function AppDetail() {
 	const [showRemovePortDialog, setShowRemovePortDialog] = useState(false);
 	const [pendingRemovePort, setPendingRemovePort] = useState<PortMapping | null>(null);
 	const [portRemoveSubmitting, setPortRemoveSubmitting] = useState(false);
+
+	const routingDiagnosticsEnabled =
+		(activeTab === "settings" || activeTab === "ssl") && !!name;
+	const {
+		data: portConflictsData,
+		isLoading: portConflictsLoading,
+		refetch: refetchPortConflicts,
+	} = useQuery({
+		queryKey: queryKeys.apps.portConflicts,
+		queryFn: () => apiFetch("/apps/port-conflicts", PortConflictsResponseSchema),
+		enabled: routingDiagnosticsEnabled,
+	});
+	const routingIssues = useMemo(
+		() =>
+			name
+				? buildRoutingIssues(name, ports, portConflictsData?.conflicts ?? [])
+				: [],
+		[name, ports, portConflictsData?.conflicts]
+	);
 
 	// Proxy query
 	const {
@@ -737,6 +760,7 @@ export function AppDetail() {
 				setNewHostPort("");
 				setNewContainerPort("");
 				void refetchPorts();
+				void refetchPortConflicts();
 			},
 		});
 
@@ -764,6 +788,7 @@ export function AppDetail() {
 				setShowRemovePortDialog(false);
 				setPendingRemovePort(null);
 				void refetchPorts();
+				void refetchPortConflicts();
 			},
 			onError: () => {
 				setShowRemovePortDialog(false);
@@ -784,6 +809,7 @@ export function AppDetail() {
 			onSuccess: () => {
 				setShowClearPortsDialog(false);
 				void refetchPorts();
+				void refetchPortConflicts();
 			},
 			onError: () => {
 				setShowClearPortsDialog(false);
@@ -1167,11 +1193,7 @@ export function AppDetail() {
 	}
 
 	if (error || !app) {
-		return (
-			<div className={alertBannerClass("error")}>
-				{error || "App not found"}
-			</div>
-		);
+		return <div className={alertBannerClass("error")}>{error || "App not found"}</div>;
 	}
 
 	return (
@@ -1546,21 +1568,31 @@ export function AppDetail() {
 			)}
 
 			{activeTab === "ssl" && (
-				<AppSSL
-					sslStatus={sslStatus ?? null}
-					loading={sslLoading}
-					error={sslError}
-					email={sslEmail}
-					submitting={sslSubmitting}
-					canModify={canModify}
-					onEmailChange={setSslEmail}
-					onEnable={handleEnableSSL}
-					onRenew={handleRenewSSL}
-				/>
+				<>
+					<AppRoutingIssues
+						issues={routingIssues}
+						loading={portConflictsLoading || portsLoading}
+					/>
+					<AppSSL
+						sslStatus={sslStatus ?? null}
+						loading={sslLoading}
+						error={sslError}
+						email={sslEmail}
+						submitting={sslSubmitting}
+						canModify={canModify}
+						onEmailChange={setSslEmail}
+						onEnable={handleEnableSSL}
+						onRenew={handleRenewSSL}
+					/>
+				</>
 			)}
 
 			{activeTab === "settings" && (
 				<div className="space-y-6">
+					<AppRoutingIssues
+						issues={routingIssues}
+						loading={portConflictsLoading || portsLoading}
+					/>
 					<AppDeployment
 						settings={deploymentSettings ?? null}
 						loading={deploymentLoading}

--- a/client/src/pages/AppDetail/index.tsx
+++ b/client/src/pages/AppDetail/index.tsx
@@ -26,7 +26,7 @@ import {
 	ProxyReportSchema,
 	SSLStatusSchema,
 } from "../../lib/schemas.js";
-import { buildRoutingIssues } from "../../lib/routing-issues.js";
+import { buildRoutingIssues } from "@/lib/routing-issues.js";
 import { AppDetailHeader } from "./AppDetailHeader.js";
 import { AppOverview } from "./AppOverview.js";
 import { AppLogs } from "./AppLogs.js";
@@ -229,7 +229,7 @@ export function AppDetail() {
 			name
 				? buildRoutingIssues(name, ports, portConflictsData?.conflicts ?? [])
 				: [],
-		[name, ports, portConflictsData?.conflicts]
+		[name, portsData?.ports, portConflictsData?.conflicts]
 	);
 
 	// Proxy query

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -445,10 +445,8 @@ dokku proxy:ports-remove "${APP_NAME}" http:8008:3001   # example — use your a
 dokku proxy:ports-add "${APP_NAME}" http:80:3001
 dokku proxy:build-config "${APP_NAME}"
 
-# 3) If a system nginx package is installed and conflicts with Dokku:
-systemctl is-active nginx
-# If active and Dokku should own 80/443, stop/disable host nginx after confirming Dokku nginx is up:
-# systemctl stop nginx && systemctl disable nginx
+# 3) Confirm Dokku nginx is serving this vhost (do not stop the host nginx service on a standard Dokku install — Dokku uses it for reverse proxying):
+dokku nginx:show-config "${APP_NAME}" | head -20
 
 # 4) Retry certificate
 dokku letsencrypt:enable "${APP_NAME}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -419,6 +419,43 @@ After step 6 the app is reachable at `https://hermes-hub.yourdomain.com` on bare
 - `ufw status` / cloud-provider firewall allows **80** and **443** inbound
 - The container actually listens on the port shown as "container port" — verify with `dokku logs hermes-hub` and the app's own startup message
 
+### Let's Encrypt HTTP-01 returns 404 on `/.well-known/acme-challenge/...`
+
+Example error:
+
+```text
+invalid authorization: ... Invalid response from http://docklight.example.com/.well-known/acme-challenge/...: 404
+```
+
+Often **port 80 is not served by Dokku** for that hostname. A host-level nginx (default welcome page, `Content-Length: 615`, old `Last-Modified`) or another reverse proxy answers instead, so the ACME proxy never sees the challenge.
+
+**On the server (as root):**
+
+```bash
+APP_NAME=docklight
+
+# 1) See who owns port 80
+ss -tlnp | grep ':80 '
+curl -sI http://127.0.0.1/ -H 'Host: docklight.itman.fyi' | head -5
+
+# 2) Docklight listens on 3001 in the container (see Dockerfile)
+dokku proxy:ports "${APP_NAME}"
+# If http is NOT host port 80, remap (adjust container port if your report differs):
+dokku proxy:ports-remove "${APP_NAME}" http:8008:3001   # example — use your actual mapping
+dokku proxy:ports-add "${APP_NAME}" http:80:3001
+dokku proxy:build-config "${APP_NAME}"
+
+# 3) If a system nginx package is installed and conflicts with Dokku:
+systemctl is-active nginx
+# If active and Dokku should own 80/443, stop/disable host nginx after confirming Dokku nginx is up:
+# systemctl stop nginx && systemctl disable nginx
+
+# 4) Retry certificate
+dokku letsencrypt:enable "${APP_NAME}"
+```
+
+**Quick external check:** `curl -sI http://docklight.itman.fyi/` should **not** look like a static default page; after fixing, you should get Docklight or an HTTP→HTTPS redirect, and `letsencrypt:enable` should succeed.
+
 > **Note:** The Docklight one-line installer handles all of this automatically when you pass `DOMAIN=…` plus `ENABLE_HTTPS=1 LETSENCRYPT_EMAIL=…`. The steps above are for apps deployed separately (any app, not just Docklight), or when you skipped those flags and want to add HTTPS after the fact.
 
 ### `dokku git:sync` fails on a private GitHub repo
@@ -562,6 +599,59 @@ ssh root@<server-ip> dokku nginx:report <app> | grep -i 'client max body size'
 ```
 
 If you set it but uploads still fail at 1 MB, you forgot `dokku proxy:build-config <app>` (or there's a separate reverse proxy in front, e.g. Cloudflare's own 100 MB cap on the Free plan — check that too).
+
+### Wrong TLS certificate (hostname mismatch)
+
+Browsers and `curl` fail with:
+
+```text
+SSL: no alternative certificate subject name matches target host name 'docklight.example.com'
+```
+
+or the certificate `subject` shows a **different** app domain (e.g. you open `docklight.itman.fyi` but the cert is for `ai-flow-staging.itman.fyi`).
+
+**Cause:** The Dokku app behind that hostname does not have the domain attached and/or Let's Encrypt was never issued for that app. Nginx then serves another vhost's default certificate.
+
+**Diagnose from your laptop:**
+
+```bash
+dig +short docklight.example.com
+openssl s_client -connect docklight.example.com:443 -servername docklight.example.com </dev/null 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+**Fix on the Dokku server (as root):**
+
+```bash
+# Replace app name, domain, and email
+APP_NAME=docklight
+DOMAIN=docklight.itman.fyi
+LETSENCRYPT_EMAIL=you@example.com
+
+dokku domains:report "${APP_NAME}"
+dokku domains:set "${APP_NAME}" "${DOMAIN}"
+
+dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git 2>/dev/null || true
+dokku letsencrypt:set "${APP_NAME}" email "${LETSENCRYPT_EMAIL}"
+dokku letsencrypt:enable "${APP_NAME}"
+dokku letsencrypt:cron-job --add
+```
+
+Or run the helper script from this repo:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jellydn/docklight/main/scripts/repair-ssl.sh \
+  | sudo APP_NAME=docklight DOMAIN=docklight.itman.fyi LETSENCRYPT_EMAIL=you@example.com bash
+```
+
+**Checklist:**
+
+- `dig +short <domain>` returns your server IP
+- `dokku domains:report docklight` lists `<domain>`
+- Inbound **80** and **443** are open (UFW / cloud firewall)
+- If HTTP-01 fails, see **"App URL shows a random `:NNNN` port"** above and map proxy `http:80:<container-port>`
+
+Production deploys via GitHub Actions (`.github/workflows/deploy-production.yml`) only `git push` code; they do **not** configure domains or SSL. Set domain + Let's Encrypt once on the server (or use `scripts/install.sh` with `DOMAIN=… ENABLE_HTTPS=1 LETSENCRYPT_EMAIL=…`).
 
 ### "Could not resolve hostname"
 

--- a/scripts/repair-ssl.sh
+++ b/scripts/repair-ssl.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Repair HTTPS for a Dokku app (domain + Let's Encrypt).
+# Run on the Dokku server as root.
+#
+# Usage:
+#   sudo APP_NAME=docklight DOMAIN=docklight.itman.fyi LETSENCRYPT_EMAIL=you@example.com bash scripts/repair-ssl.sh
+#
+# Or from the repo on the server:
+#   curl -fsSL .../repair-ssl.sh | sudo APP_NAME=docklight DOMAIN=docklight.itman.fyi LETSENCRYPT_EMAIL=you@example.com bash
+#
+# Environment:
+#   APP_NAME           Dokku app (default: docklight)
+#   DOMAIN             FQDN that must appear on the certificate (required)
+#   LETSENCRYPT_EMAIL  ACME account email (required)
+#   FIX_PROXY_PORT     If 1, remap http host port to 80 when not already on 80 (default: 0)
+
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-docklight}"
+DOMAIN="${DOMAIN:-}"
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
+FIX_PROXY_PORT="${FIX_PROXY_PORT:-0}"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+err() {
+	printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2
+	exit 1
+}
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+	err "Run as root (sudo bash)"
+fi
+
+if [[ -z "${DOMAIN}" ]]; then
+	err "DOMAIN is required (e.g. DOMAIN=docklight.itman.fyi)"
+fi
+if [[ -z "${LETSENCRYPT_EMAIL}" ]]; then
+	err "LETSENCRYPT_EMAIL is required for Let's Encrypt"
+fi
+
+if ! dokku apps:exists "${APP_NAME}" 2>/dev/null; then
+	err "App '${APP_NAME}' does not exist"
+fi
+
+log "Domains for ${APP_NAME} (before):"
+dokku domains:report "${APP_NAME}" || true
+
+log "Setting app domain to ${DOMAIN}"
+dokku domains:set "${APP_NAME}" "${DOMAIN}"
+
+if [[ "${FIX_PROXY_PORT}" == "1" ]]; then
+	log "Checking proxy port mapping"
+	mapfile -t port_lines < <(dokku proxy:ports "${APP_NAME}" 2>/dev/null | awk 'NR>1 && $1=="http" {print $2,$3}')
+	if [[ ${#port_lines[@]} -eq 1 ]]; then
+		read -r host_port container_port <<<"${port_lines[0]}"
+		if [[ "${host_port}" != "80" && -n "${container_port}" ]]; then
+			log "Remapping http:${host_port}:${container_port} -> http:80:${container_port}"
+			dokku proxy:ports-remove "${APP_NAME}" "http:${host_port}:${container_port}"
+			dokku proxy:ports-add "${APP_NAME}" "http:80:${container_port}"
+		fi
+	fi
+fi
+
+if ! dokku plugin:list 2>/dev/null | grep -q letsencrypt; then
+	log "Installing dokku-letsencrypt plugin"
+	dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
+fi
+
+log "Configuring Let's Encrypt email"
+dokku letsencrypt:set "${APP_NAME}" email "${LETSENCRYPT_EMAIL}"
+
+log "Enabling / renewing certificate for ${DOMAIN}"
+if ! dokku letsencrypt:enable "${APP_NAME}"; then
+	warn "letsencrypt:enable failed — try: dokku letsencrypt:renew ${APP_NAME}"
+	warn "Ensure DNS: dig +short ${DOMAIN} matches this server's public IP"
+	warn "Ensure inbound TCP 80 and 443 are open"
+	exit 1
+fi
+
+dokku letsencrypt:cron-job --add 2>/dev/null || true
+
+log "Certificate check (openssl SNI=${DOMAIN}):"
+echo | openssl s_client -connect "${DOMAIN}:443" -servername "${DOMAIN}" 2>/dev/null \
+	| openssl x509 -noout -subject -dates 2>/dev/null || warn "Could not read certificate from ${DOMAIN}:443"
+
+log "Done. Test: curl -fsSI https://${DOMAIN}/ | head -5"

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -1,18 +1,9 @@
 import { executeCommand, type CommandResult } from "./executor.js";
 import { isValidAppName } from "./apps.js";
 import { DokkuCommands } from "./dokku.js";
+import { validateConfigKey } from "./env-config-key.js";
 
-const CONFIG_KEY_PATTERN = /^[a-zA-Z0-9_]+$/;
-
-export function validateConfigKey(key: string): string | null {
-	if (typeof key !== "string" || key.length === 0) {
-		return "Config key is required";
-	}
-	if (!CONFIG_KEY_PATTERN.test(key)) {
-		return "Invalid characters in key";
-	}
-	return null;
-}
+export { validateConfigKey } from "./env-config-key.js";
 
 export async function getConfig(
 	name: string

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -2,6 +2,18 @@ import { executeCommand, type CommandResult } from "./executor.js";
 import { isValidAppName } from "./apps.js";
 import { DokkuCommands } from "./dokku.js";
 
+const CONFIG_KEY_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+export function validateConfigKey(key: string): string | null {
+	if (typeof key !== "string" || key.length === 0) {
+		return "Config key is required";
+	}
+	if (!CONFIG_KEY_PATTERN.test(key)) {
+		return "Invalid characters in key";
+	}
+	return null;
+}
+
 export async function getConfig(
 	name: string
 ): Promise<
@@ -65,11 +77,11 @@ export async function setConfig(
 		};
 	}
 
-	// Key must be alphanumeric + underscore (env var convention)
-	const sanitizedKey = key.replace(/[^a-zA-Z0-9_]/g, "");
-	if (sanitizedKey !== key) {
-		return { error: "Invalid characters in key", command: "", exitCode: 400 };
+	const keyError = validateConfigKey(key);
+	if (keyError) {
+		return { error: keyError, command: "", exitCode: 400 };
 	}
+	const sanitizedKey = key;
 
 	// Value: block shell injection but allow common chars like quotes, @, #, etc.
 	if (/[`$;|<>\\]/.test(value)) {
@@ -106,18 +118,12 @@ export async function unsetConfig(
 		};
 	}
 
-	// Sanitize key to prevent shell injection
-	const sanitizedKey = key.replace(/[^a-zA-Z0-9_]/g, "");
-
-	if (sanitizedKey !== key) {
-		return {
-			error: "Invalid characters in key",
-			command: "",
-			exitCode: 400,
-		};
+	const keyError = validateConfigKey(key);
+	if (keyError) {
+		return { error: keyError, command: "", exitCode: 400 };
 	}
 
-	const command = DokkuCommands.configUnset(name, sanitizedKey);
+	const command = DokkuCommands.configUnset(name, key);
 
 	try {
 		return executeCommand(command);

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -80,14 +80,20 @@ describe("DokkuCommands", () => {
 			expect(DokkuCommands.configShow("my-app")).toBe("dokku config:show my-app");
 		});
 
-		it("configSet returns config:set command with quoted value", () => {
+		it("configSet returns config:set command with quoted value only", () => {
 			expect(DokkuCommands.configSet("my-app", "KEY", "value")).toBe(
-				"dokku config:set 'my-app' 'KEY'='value'"
+				"dokku config:set 'my-app' KEY='value'"
 			);
 		});
 
-		it("configUnset returns config:unset command", () => {
-			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' 'KEY'");
+		it("configSet does not quote env var keys", () => {
+			expect(
+				DokkuCommands.configSet("my-app", "SUPER_ADMIN_BOOTSTRAP_EMAIL", "admin@example.com")
+			).toBe("dokku config:set 'my-app' SUPER_ADMIN_BOOTSTRAP_EMAIL='admin@example.com'");
+		});
+
+		it("configUnset returns config:unset command without quoting key", () => {
+			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' KEY");
 		});
 	});
 

--- a/server/lib/dokku.test.ts
+++ b/server/lib/dokku.test.ts
@@ -95,6 +95,12 @@ describe("DokkuCommands", () => {
 		it("configUnset returns config:unset command without quoting key", () => {
 			expect(DokkuCommands.configUnset("my-app", "KEY")).toBe("dokku config:unset 'my-app' KEY");
 		});
+
+		it("configSet rejects invalid keys before building command", () => {
+			expect(() => DokkuCommands.configSet("my-app", "KEY;evil", "x")).toThrow(
+				/Invalid characters/
+			);
+		});
 	});
 
 	describe("plugins", () => {

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -1,4 +1,5 @@
 import { executeCommand } from "./executor.js";
+import { assertValidConfigKey } from "./env-config-key.js";
 import { shellQuote } from "./shell.js";
 
 export interface GitSyncResult {
@@ -153,9 +154,14 @@ export const DokkuCommands: DokkuCommands = {
 
 	// Config
 	configShow: (app: string): string => `dokku config:show ${app}`,
-	configSet: (app: string, key: string, value: string): string =>
-		`dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`,
-	configUnset: (app: string, key: string): string => `dokku config:unset ${shellQuote(app)} ${key}`,
+	configSet: (app: string, key: string, value: string): string => {
+		assertValidConfigKey(key);
+		return `dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`;
+	},
+	configUnset: (app: string, key: string): string => {
+		assertValidConfigKey(key);
+		return `dokku config:unset ${shellQuote(app)} ${key}`;
+	},
 
 	// Plugins (read-only)
 	pluginList: (): string => "dokku plugin:list",

--- a/server/lib/dokku.ts
+++ b/server/lib/dokku.ts
@@ -154,9 +154,8 @@ export const DokkuCommands: DokkuCommands = {
 	// Config
 	configShow: (app: string): string => `dokku config:show ${app}`,
 	configSet: (app: string, key: string, value: string): string =>
-		`dokku config:set ${shellQuote(app)} ${shellQuote(key)}=${shellQuote(value)}`,
-	configUnset: (app: string, key: string): string =>
-		`dokku config:unset ${shellQuote(app)} ${shellQuote(key)}`,
+		`dokku config:set ${shellQuote(app)} ${key}=${shellQuote(value)}`,
+	configUnset: (app: string, key: string): string => `dokku config:unset ${shellQuote(app)} ${key}`,
 
 	// Plugins (read-only)
 	pluginList: (): string => "dokku plugin:list",

--- a/server/lib/env-config-key.test.ts
+++ b/server/lib/env-config-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { assertValidConfigKey, validateConfigKey } from "./env-config-key.js";
+
+describe("validateConfigKey", () => {
+	it("accepts valid env var names", () => {
+		expect(validateConfigKey("SUPER_ADMIN_BOOTSTRAP_EMAIL")).toBeNull();
+		expect(validateConfigKey("NODE_ENV")).toBeNull();
+	});
+
+	it("rejects injection attempts", () => {
+		expect(validateConfigKey("KEY;rm -rf /")).not.toBeNull();
+		expect(validateConfigKey("'KEY'")).not.toBeNull();
+		expect(validateConfigKey("")).not.toBeNull();
+	});
+});
+
+describe("assertValidConfigKey", () => {
+	it("throws for invalid keys", () => {
+		expect(() => assertValidConfigKey("bad key")).toThrow(/Invalid characters/);
+	});
+});

--- a/server/lib/env-config-key.ts
+++ b/server/lib/env-config-key.ts
@@ -1,0 +1,18 @@
+const CONFIG_KEY_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+export function validateConfigKey(key: string): string | null {
+	if (typeof key !== "string" || key.length === 0) {
+		return "Config key is required";
+	}
+	if (!CONFIG_KEY_PATTERN.test(key)) {
+		return "Invalid characters in key";
+	}
+	return null;
+}
+
+export function assertValidConfigKey(key: string): void {
+	const error = validateConfigKey(key);
+	if (error) {
+		throw new Error(error);
+	}
+}

--- a/server/lib/port-conflicts.test.ts
+++ b/server/lib/port-conflicts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	appHasHttpOnPort80,
+	conflictsForApp,
+	detectPortConflictsFromMappings,
+} from "./port-conflicts.js";
+
+describe("detectPortConflictsFromMappings", () => {
+	it("returns empty when no apps share a host port", () => {
+		const result = detectPortConflictsFromMappings({
+			docklight: [{ scheme: "http", hostPort: 80, containerPort: 3001 }],
+			other: [{ scheme: "http", hostPort: 8008, containerPort: 3000 }],
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("detects two apps on the same http host port", () => {
+		const result = detectPortConflictsFromMappings({
+			docklight: [{ scheme: "http", hostPort: 80, containerPort: 3001 }],
+			"ai-flow-staging": [{ scheme: "http", hostPort: 80, containerPort: 3000 }],
+		});
+		expect(result).toEqual([
+			{
+				scheme: "http",
+				hostPort: 80,
+				apps: ["ai-flow-staging", "docklight"],
+			},
+		]);
+	});
+
+	it("does not treat different schemes on same numeric port as one conflict bucket", () => {
+		const result = detectPortConflictsFromMappings({
+			a: [
+				{ scheme: "http", hostPort: 443, containerPort: 3000 },
+				{ scheme: "https", hostPort: 443, containerPort: 3000 },
+			],
+			b: [{ scheme: "http", hostPort: 443, containerPort: 3001 }],
+		});
+		expect(result).toEqual([{ scheme: "http", hostPort: 443, apps: ["a", "b"] }]);
+	});
+});
+
+describe("conflictsForApp", () => {
+	it("filters conflicts involving the app", () => {
+		const conflicts = [
+			{ scheme: "http", hostPort: 80, apps: ["docklight", "ai-flow-staging"] },
+			{ scheme: "http", hostPort: 8008, apps: ["other", "another"] },
+		];
+		expect(conflictsForApp(conflicts, "docklight")).toEqual([conflicts[0]]);
+	});
+});
+
+describe("appHasHttpOnPort80", () => {
+	it("returns true when http maps to host 80", () => {
+		expect(
+			appHasHttpOnPort80([{ scheme: "http", hostPort: 80, containerPort: 3001 }])
+		).toBe(true);
+	});
+
+	it("returns false when http uses a high port", () => {
+		expect(
+			appHasHttpOnPort80([{ scheme: "http", hostPort: 8008, containerPort: 3001 }])
+		).toBe(false);
+	});
+});

--- a/server/lib/port-conflicts.ts
+++ b/server/lib/port-conflicts.ts
@@ -1,0 +1,83 @@
+import { listAppNames } from "./apps.js";
+import { getPorts, type PortMapping } from "./ports.js";
+
+export interface PortConflict {
+	scheme: string;
+	hostPort: number;
+	apps: string[];
+}
+
+export interface PortConflictsResult {
+	conflicts: PortConflict[];
+}
+
+function conflictKey(scheme: string, hostPort: number): string {
+	return `${scheme.toLowerCase()}:${hostPort}`;
+}
+
+export function detectPortConflictsFromMappings(
+	appPorts: Record<string, PortMapping[]>
+): PortConflict[] {
+	const byKey = new Map<string, Set<string>>();
+
+	for (const [appName, ports] of Object.entries(appPorts)) {
+		for (const port of ports) {
+			const key = conflictKey(port.scheme, port.hostPort);
+			const apps = byKey.get(key) ?? new Set<string>();
+			apps.add(appName);
+			byKey.set(key, apps);
+		}
+	}
+
+	const conflicts: PortConflict[] = [];
+	for (const [key, apps] of byKey) {
+		if (apps.size < 2) {
+			continue;
+		}
+		const [scheme, hostPortStr] = key.split(":");
+		conflicts.push({
+			scheme,
+			hostPort: Number.parseInt(hostPortStr, 10),
+			apps: [...apps].sort(),
+		});
+	}
+
+	conflicts.sort((a, b) => a.hostPort - b.hostPort || a.scheme.localeCompare(b.scheme));
+	return conflicts;
+}
+
+export async function getPortConflicts(userId?: string): Promise<
+	| PortConflictsResult
+	| { error: string; command: string; exitCode: number; stderr: string }
+> {
+	const listResult = await listAppNames(userId);
+	if (!listResult.ok) {
+		return {
+			error: listResult.error.stderr || "Failed to list apps",
+			command: listResult.error.command,
+			exitCode: listResult.error.exitCode,
+			stderr: listResult.error.stderr,
+		};
+	}
+
+	const appPorts: Record<string, PortMapping[]> = {};
+	for (const appName of listResult.names) {
+		const ports = await getPorts(appName);
+		if (Array.isArray(ports)) {
+			appPorts[appName] = ports;
+		}
+	}
+
+	return { conflicts: detectPortConflictsFromMappings(appPorts) };
+}
+
+export function conflictsForApp(
+	conflicts: PortConflict[],
+	appName: string
+): PortConflict[] {
+	return conflicts.filter((c) => c.apps.includes(appName));
+}
+
+export function appHasHttpOnPort80(ports: PortMapping[]): boolean {
+	return ports.some((p) => p.scheme.toLowerCase() === "http" && p.hostPort === 80);
+}

--- a/server/lib/port-conflicts.ts
+++ b/server/lib/port-conflicts.ts
@@ -60,9 +60,14 @@ export async function getPortConflicts(userId?: string): Promise<
 		};
 	}
 
+	const portResults = await Promise.all(
+		listResult.names.map(async (appName) => {
+			const ports = await getPorts(appName);
+			return { appName, ports };
+		})
+	);
 	const appPorts: Record<string, PortMapping[]> = {};
-	for (const appName of listResult.names) {
-		const ports = await getPorts(appName);
+	for (const { appName, ports } of portResults) {
 		if (Array.isArray(ports)) {
 			appPorts[appName] = ports;
 		}

--- a/server/routes/app-config.ts
+++ b/server/routes/app-config.ts
@@ -1,5 +1,5 @@
 import type express from "express";
-import { getConfig, setConfig, unsetConfig } from "../lib/config.js";
+import { getConfig, setConfig, unsetConfig, validateConfigKey } from "../lib/config.js";
 import { clearPrefix } from "../lib/cache.js";
 import { authMiddleware, requireOperator } from "../lib/auth.js";
 import { DokkuCommands } from "../lib/dokku.js";
@@ -22,6 +22,11 @@ export function registerAppConfigRoutes(app: express.Application): void {
 		if (isSSERequest(req)) {
 			if (!isValidAppName(name) || !key) {
 				res.status(400).json({ error: "Invalid app name or key" });
+				return;
+			}
+			const keyError = validateConfigKey(key);
+			if (keyError) {
+				res.status(400).json({ error: keyError });
 				return;
 			}
 			await streamAction(req, res, {
@@ -50,6 +55,11 @@ export function registerAppConfigRoutes(app: express.Application): void {
 		if (isSSERequest(req)) {
 			if (!isValidAppName(name) || !key) {
 				res.status(400).json({ error: "Invalid app name or key" });
+				return;
+			}
+			const unsetKeyError = validateConfigKey(key);
+			if (unsetKeyError) {
+				res.status(400).json({ error: unsetKeyError });
 				return;
 			}
 			await streamAction(req, res, {

--- a/server/routes/app-ports.ts
+++ b/server/routes/app-ports.ts
@@ -7,15 +7,35 @@ import {
 	validatePort,
 	validateScheme,
 } from "../lib/ports.js";
+import { getPortConflicts } from "../lib/port-conflicts.js";
 import { clearPrefix, get, set } from "../lib/cache.js";
 import { authMiddleware, requireOperator } from "../lib/auth.js";
 import { DokkuCommands } from "../lib/dokku.js";
 import { isSSERequest } from "../lib/sse.js";
 import { isValidAppName } from "../lib/apps.js";
-import { getParam, handleCommandResult, getStatusCode } from "./util.js";
+import { getParam, getStatusCode, getUserId, handleCommandResult } from "./util.js";
 import { streamAction } from "./stream-util.js";
 
 export function registerAppPortRoutes(app: express.Application): void {
+	app.get("/api/apps/port-conflicts", authMiddleware, async (req, res) => {
+		const cacheKey = "apps:port-conflicts";
+		const cached = get(cacheKey);
+		if (cached) {
+			res.json(cached);
+			return;
+		}
+
+		const userId = getUserId(req);
+		const result = await getPortConflicts(userId);
+		if ("error" in result && result.error) {
+			res.status(getStatusCode(result.exitCode)).json(result);
+			return;
+		}
+
+		set(cacheKey, result, 30_000);
+		res.json(result);
+	});
+
 	app.get("/api/apps/:name/ports", authMiddleware, async (req, res) => {
 		const name = getParam(req.params, "name");
 		const cacheKey = `apps:${name}:ports`;

--- a/server/routes/app-ports.ts
+++ b/server/routes/app-ports.ts
@@ -18,14 +18,14 @@ import { streamAction } from "./stream-util.js";
 
 export function registerAppPortRoutes(app: express.Application): void {
 	app.get("/api/apps/port-conflicts", authMiddleware, async (req, res) => {
-		const cacheKey = "apps:port-conflicts";
+		const userId = getUserId(req);
+		const cacheKey = `apps:port-conflicts:${userId ?? "anonymous"}`;
 		const cached = get(cacheKey);
 		if (cached) {
 			res.json(cached);
 			return;
 		}
 
-		const userId = getUserId(req);
 		const result = await getPortConflicts(userId);
 		if ("error" in result && result.error) {
 			res.status(getStatusCode(result.exitCode)).json(result);


### PR DESCRIPTION
## What

- API `GET /api/apps/port-conflicts` scans all Dokku apps and reports host ports mapped by more than one app
- App **Settings** and **SSL** tabs show routing warnings (e.g. docklight + ai-flow-staging both on http:80)
- Ports section hint about unique host ports
- Includes prior `config:set` env key quoting fix and SSL repair/docs from this branch

## Why

Multiple apps sharing host port 80 caused wrong TLS certs and Let's Encrypt HTTP-01 404s on docklight.itman.fyi. Operators need to see conflicts in Docklight before enabling SSL.

## How

- `server/lib/port-conflicts.ts` aggregates `dokku ports:report` per app
- Client `buildRoutingIssues()` turns conflicts into actionable banners
- Refetch conflicts after port add/remove/clear

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing diagnostics to app settings and SSL pages.
  * Detects shared host ports, HTTP port 80 conflicts, and missing port 80 mappings.
  * Displays actionable warnings and errors for port and HTTPS configuration issues.
  * Added an HTTPS repair script for domain, proxy, and Let’s Encrypt setup.

* **Documentation**
  * Added troubleshooting guidance for Let’s Encrypt failures and incorrect TLS certificates.

* **Bug Fixes**
  * Improved environment-variable command formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->